### PR TITLE
Added .read() to extra_vars parameter as it is a File.

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -74,7 +74,7 @@ class Resource(models.BaseResource):
         # If the job template requires prompting for extra variables,
         # do so (unless --no-input is set).
         if extra_vars:
-            data['extra_vars'] = extra_vars
+            data['extra_vars'] = extra_vars.read()
         elif data.pop('ask_variables_on_launch', False) and not no_input:
             initial = data['extra_vars']
             initial = '\n'.join((


### PR DESCRIPTION
extra_vars in job.launch must be read before it's added to the data dictionary.  Otherwise, an "is not JSON serializable" exception will result as the requests http lib will attempt to serialize the open file object.
