### PR TITLE
Option for dynamic inventory group to sync respective sources

### DIFF
--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -125,12 +125,12 @@ class Resource(models.Resource):
 
     @click.argument('group', type=types.Related('group'))
     @resources.command(use_fields_as_options=False, no_args_is_help=True)
-    def update(self, group, **kwargs):
+    def sync(self, group, **kwargs):
         """Update the given group's inventory source."""
 
         isrc = get_resource('inventory_source')
         isid = self._get_inventory_source_id(group)
-        return isrc.update(isid, **kwargs)
+        return isrc.sync(isid, **kwargs)
 
     def _get_inventory_source_id(self, group):
         """Return the inventory source ID given a group dictionary returned

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -31,11 +31,11 @@ class Resource(models.Resource):
         default='manual',
         help_text='The type of inventory source in use.',
         type=click.Choice(['manual', 'ec2', 'rax', 'gce', 'azure']),
-    )    
+    )
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))
     @resources.command(use_fields_as_options=False, no_args_is_help=True)
-    def update(self, inventory_source, **kwargs):
+    def sync(self, inventory_source, **kwargs):
         """Update the given inventory source."""
 
         # Establish that we are able to update this inventory source

--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -155,17 +155,17 @@ class GroupTests(unittest.TestCase):
                 source='rax', credential=None, force_on_exists=True,
             )
 
-    def test_update(self):
-        """Establish that the update method correctly forwards to the
+    def test_sync(self):
+        """Establish that the sync method correctly forwards to the
         inventory source method, after getting the inventory source ID.
         """
         isrc = tower_cli.get_resource('inventory_source')
-        with mock.patch.object(type(isrc), 'update') as isrc_update:
+        with mock.patch.object(type(isrc), 'sync') as isrc_sync:
             with client.test_mode as t:
                 t.register_json('/groups/1/', {
                     'id': 1, 'name': 'foo', 'inventory': 1,
                     'related': {'inventory_source': '/inventory_sources/42/'},
                 }, method='GET')
-                self.gr.update(1)
-                isrc_update.assert_called_once_with(42)
+                self.gr.sync(1)
+                isrc_sync.assert_called_once_with(42)
                 self.assertEqual(len(t.requests), 1)

--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -27,24 +27,24 @@ class InventorySourceTests(unittest.TestCase):
     def setUp(self):
         self.isr = tower_cli.get_resource('inventory_source')
 
-    def test_cannot_update(self):
-        """Establish that if we attempt to update an inventory source that
+    def test_cannot_sync(self):
+        """Establish that if we attempt to sync an inventory source that
         cannot be updated, that we raise BadRequest.
         """
         with client.test_mode as t:
             t.register_json('/inventory_sources/1/update/',
                             {'can_update': False}, method='GET')
             with self.assertRaises(exc.BadRequest):
-                self.isr.update(1)
+                self.isr.sync(1)
 
-    def test_update(self):
+    def test_sync(self):
         """Establish that if we are able to update an inventory source,
-        that the update command does so.
+        that the sync command does so.
         """
         with client.test_mode as t:
             t.register_json('/inventory_sources/1/update/',
                             {'can_update': True}, method='GET')
             t.register_json('/inventory_sources/1/update/',
                             {}, method='POST')
-            answer = self.isr.update(1)
+            answer = self.isr.sync(1)
             self.assertEqual(answer['status'], 'ok')


### PR DESCRIPTION
Would be great if we could force an inventory synch for groups with dynamic sources. 
