### PR TITLE
travis-ci execute test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+#  - "2.6"
+  - "2.7"
+#  - "3.3"
+#  - "3.4"
+# command to install dependencies
+install: 
+  - "sudo pip install ."
+  - "sudo pip install -r requirements.txt"
+script:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then sudo python setup.py test -a "-epy2.7"; fi

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ class Tox(TestCommand):
 
     Based on http://tox.readthedocs.org/en/latest/example/basic.html
     """
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = ""
+
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
@@ -37,8 +42,8 @@ class Tox(TestCommand):
 
     def run_tests(self):
         import tox  # Import here, because outside eggs aren't loaded.
-        sys.exit(tox.cmdline(self.test_args))
-
+        import shlex
+        sys.exit(tox.cmdline(args=shlex.split(self.tox_args)))
 
 def parse_requirements(filename):
     """Parse out a list of requirements from the given requirements


### PR DESCRIPTION
Added travis-ci directive to test with python 2.7. I didn't find an elegant way to allow for testing against other versions of python. I attribute this to travis-ci's naming of the python binaries. For example python 3.3 supported binary is named python3.3.5 to express the exact patch.