### PR TITLE
Remove egg_base=/tmp  in setup.cfg to allow installation on Windows machines via pip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[egg_info]
-egg_base = /tmp
-
-
 [nosetests]
 # don't wrap stdout/stderr
 nocapture=1


### PR DESCRIPTION
This should not break other installations.  But currently installation via pip causes the error:

`error: error in 'egg_base' option: '/tmp' does not exist or is not a directory`

towards the end of the installation process on Windows machines.  This commit fixes the problem, and allows the installation to complete successfully on Windows.

Edit:  The only thing that will obviously not work (on Windows) is the `--global` config, since it looks for the file at `/etc/awx/`.


Questions, or concerns please let me know.

Thanks,

Phil
