### PR TITLE
Added local_path to project resource.

### DIFF
--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -39,6 +39,7 @@ class Resource(models.MonitorableResource):
         ]),
     )
     scm_url = models.Field(required=False)
+    local_path = models.Field(help_text='For manual projects, the server playbook directory name', required=False)
     scm_branch = models.Field(required=False, display=False)
     scm_credential = models.Field('credential',
         display=False,


### PR DESCRIPTION
Manual projects can't be created from tower-cli without it. Also added clarifying help 
text for when it's applicable.