### PR TITLE
Make the stinkin' badges work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://travis-ci.org/ansible/tower-cli.svg?branch=master)](https://travis-ci.org/ansible/tower-cli)
-[![Coverage Status](https://coveralls.io/repos/ansible/tower-cli/badge.svg)](https://coveralls.io/r/ansible/tower-cli)
-[![Version](https://pypip.in/v/ansible-tower-cli/badge.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
-[![Downloads](https://pypip.in/d/ansible-tower-cli/badge.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
-[![License](https://pypip.in/license/ansible-tower-cli/badge.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
-[![Supported Python Versions](https://pypip.in/py_versions/ansible-tower-cli/badge.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
+[![Build Status](https://img.shields.io/travis/ansible/tower-cli.svg)](https://travis-ci.org/ansible/tower-cli)
+[![Coverage Status](https://img.shields.io/coveralls/ansible/tower-cli.svg)](https://coveralls.io/r/ansible/tower-cli)
+[![Version](https://img.shields.io/pypi/v/ansible-tower-cli.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
+[![Downloads](https://img.shields.io/pypi/dm/ansible-tower-cli.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
+[![License](https://img.shields.io/pypi/l/ansible-tower-cli.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/ansible-tower-cli.svg)](https://pypi.python.org/pypi/ansible-tower-cli/)
 
 
 ## Welcome to tower-cli


### PR DESCRIPTION
Fix the stinkin' badges from 4d9f3abc73a0a5398bb9a70d8c0a9d6012509a20 (and the others too) to use shields.io instead.