### PR TITLE
.tower_cli.cfg permissions set to read/write for current user only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ debian/
 cover-html
 coverage.xml
 results.xml
+
+# ignore personal configs
+.tower_cli.cfg

--- a/lib/tower_cli/commands/config.py
+++ b/lib/tower_cli/commands/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import stat
 import warnings
 
 import six
@@ -147,11 +148,11 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
     with open(filename, 'w') as config_file:
         parser.write(config_file)
     try:
-        os.chmod(filename, int('0600', 8)) # give rw permissions to user only
+        os.chmod(filename, stat.S_IRUSR | stat.S_IWUSR) # give rw permissions to user only
                                            # fix for issue number 48
     except Exception as e:
         warnings.warn('Unable to set permissions on {0} - {1} '.format(filename,e),
-                            UserWarning)
+                      UserWarning)
     click.echo('Configuration updated successfully.')
 
 

--- a/lib/tower_cli/commands/config.py
+++ b/lib/tower_cli/commands/config.py
@@ -146,6 +146,12 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
         parser.set('general', key, value)
     with open(filename, 'w') as config_file:
         parser.write(config_file)
+    try:
+        os.chmod(filename, int('0600', 8)) # give rw permissions to user only
+                                           # fix for issue number 48
+    except Exception as e:
+        warnings.warn('Unable to set permissions on {0} - {1} '.format(filename,e),
+                            UserWarning)
     click.echo('Configuration updated successfully.')
 
 

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -16,13 +16,12 @@
 import contextlib
 import copy
 import os
+import stat
 import warnings
 
 import six
 from six.moves import configparser
 from six import StringIO
-
-from sdict import adict
 
 
 class Parser(configparser.ConfigParser):
@@ -42,11 +41,10 @@ class Parser(configparser.ConfigParser):
         # other users, raise a warning
         if os.path.isfile(fpname):
             file_permission = os.stat(fpname)
-            nth_permission = [(file_permission.st_mode/8**i)%8 for i in range(3)]
-            for i in range(2):
-                if nth_permission[i] >=4:
-                    warnings.warn('File {0} readable by group/others.'.format(fpname),
-                                    RuntimeWarning)
+            if (file_permission.st_mode & stat.S_IRGRP) or \
+               (file_permission.st_mode & stat.S_IROTH):
+                warnings.warn('File {0} readable by group or others.'
+                              .format(fpname), RuntimeWarning)
         # If it doesn't work because there's no section header, then
         # create a section header and call the superclass implementation
         # again.

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -37,6 +37,16 @@ class Parser(configparser.ConfigParser):
         """
         # Attempt to read the file using the superclass implementation.
         #
+        # Check the permissions of the file we are considering reading
+        # if the file exists and the permissions expose it to reads from
+        # other users, raise a warning
+        if os.path.isfile(fpname):
+            file_permission = os.stat(fpname)
+            nth_permission = [(file_permission.st_mode/8**i)%8 for i in range(3)]
+            for i in range(2):
+                if nth_permission[i] >=4:
+                    warnings.warn('File {0} readable by group/others.'.format(fpname),
+                                    RuntimeWarning)
         # If it doesn't work because there's no section header, then
         # create a section header and call the superclass implementation
         # again.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -69,3 +69,18 @@ class ParserTests(unittest.TestCase):
         read_file_method = getattr(parser, 'read_file', parser.readfp)
         read_file_method(StringIO('foo: bar'))
         self.assertEqual(parser.get('general', 'foo'), 'bar')
+
+    def test_file_permission_warning(self):
+        """Warn file permissions may expose credentials
+        """
+        with mock.patch.object(warnings, 'warn') as warn:
+            with mock.patch.object(os.path, 'isfile') as isfile:
+                with mock.patch.object(os, 'stat') as os_stat:
+                    isfile.return_value = True
+                    import posix
+                    test_statz = posix.stat_result([0o604,0,0,0,0,0,0,0,0,0])
+                    os_stat.return_value = test_statz # group/others can read file
+                    parser = Parser()
+                    read_file_method = getattr(parser, 'read_file', parser.readfp)
+                    read_file_method(StringIO('[general]\nfoo: bar\n'))
+                    warn.assert_called_once_with(mock.ANY, RuntimeWarning)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib/
 
 commands =
-    nosetests
+    nosetests {posargs}
 
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Previously, the configuration file was created and edited with the default umask. This commit changes that behavior so that it attempts to set the file permissions to "-rw-------" every time. That is, read/write permissions for current user, no permissions for group, and no permissions for others. The [octal numeric notation](https://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation) is 0600 for this permission.

This is desirable when the configuration file is stored in ~/.tower_cli.cfg, which is in the user's directory, as pointed out in [Issue #48](https://github.com/ansible/tower-cli/issues/48). If the flag --scope=global --scope=local is set, this will attempt to do the same thing, but the ideal behavior for those cases is less clear. Tests were added for the default scope setting and for scope=local.

One other test using warn.assert_called_once was edited to include the warning's arguments with warn.assert_called_once_with, since official documentation for the former can't be found anywhere.