### PR TITLE
Resolve #52 with special test for "create" and adjustments to "modify"

### DIFF
--- a/lib/tower_cli/resources/organization.py
+++ b/lib/tower_cli/resources/organization.py
@@ -40,3 +40,17 @@ class Resource(models.Resource):
     def disassociate(self, organization, user):
         """Disassociate a user from this organization."""
         return self._disassoc('users', organization, user)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--organization', type=types.Related('organization'))
+    @click.option('--project', type=types.Related('project'))
+    def associate_project(self, organization, project):
+        """Associate a project with this organization."""
+        return self._assoc('projects', organization, project)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--organization', type=types.Related('organization'))
+    @click.option('--project', type=types.Related('project'))
+    def disassociate_project(self, organization, project):
+        """Disassociate a project from this organization."""
+        return self._disassoc('projects', organization, project)

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -29,7 +29,7 @@ class Resource(models.MonitorableResource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'),
-                                display=False)
+                                display=False, required=False)
     scm_type = models.Field(
         type=types.MappedChoice([
             ('', 'manual'),
@@ -39,11 +39,12 @@ class Resource(models.MonitorableResource):
         ]),
     )
     scm_url = models.Field(required=False)
-    local_path = models.Field(help_text='For manual projects, the server playbook directory name', required=False)
+    local_path = models.Field(
+        help_text='For manual projects, the server playbook directory name',
+        required=False)
     scm_branch = models.Field(required=False, display=False)
-    scm_credential = models.Field('credential',
-        display=False,
-        required=False,
+    scm_credential = models.Field(
+        'credential', display=False, required=False,
         type=types.Related('credential'),
     )
     scm_clean = models.Field(type=bool, required=False, display=False)
@@ -51,6 +52,19 @@ class Resource(models.MonitorableResource):
                                         display=False)
     scm_update_on_launch = models.Field(type=bool, required=False,
                                         display=False)
+
+    def create(self, *args, **kwargs):
+        """Fix for issue #52, second method, replacing the /projects/
+        endpoint temporarily if the project has an organization specified
+        """
+        if "organization" in kwargs:
+            debug.log("using alternative endpoint for new project",
+                      header='details')
+            org_pk = kwargs['organization']
+            self.endpoint = '/organizations/%s/projects/' % org_pk
+        to_return = super(Resource, self).create(*args, **kwargs)
+        self.endpoint = '/projects/'
+        return to_return
 
     @resources.command(use_fields_as_options=('name', 'organization'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import click
-import warnings
 
 from sdict import adict
 
@@ -67,17 +66,18 @@ class Resource(models.MonitorableResource):
         self.endpoint = '/projects/'
         return to_return
 
+    @resources.command(use_fields_as_options=(
+        'name', 'description', 'scm_type', 'scm_url', 'local_path',
+        'scm_branch', 'scm_credential', 'scm_clean', 'scm_delete_on_update',
+        'scm_update_on_launch'
+    ))
     def modify(self, *args, **kwargs):
-        """Also associated with issue #52, the organization for a project
-        can't be modified after it's created. It is handled in another
-        part of the code base with a different command. So the user is warned.
+        """Also associated with issue #52, the organization can't be modified
+        with the 'modify' command. This would create confusion about whether
+        it served the role of an identifier versus a field to modify. This
+        method is used to set the allowed fields on the modify command,
+        removing the organization from available options.
         """
-        if "organization" in kwargs:
-            warnings.warn('Option --organization is not functional.\n'
-                          'Instead, you might want to use either:\n'
-                          '   tower-cli organization associate_project, or\n'
-                          '   tower-cli organization disassociate_project\n'
-                          , UserWarning)
         return super(Resource, self).modify(*args, **kwargs)
 
     @resources.command(use_fields_as_options=('name', 'organization'))

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import click
+import warnings
 
 from sdict import adict
 
@@ -65,6 +66,19 @@ class Resource(models.MonitorableResource):
         to_return = super(Resource, self).create(*args, **kwargs)
         self.endpoint = '/projects/'
         return to_return
+
+    def modify(self, *args, **kwargs):
+        """Also associated with issue #52, the organization for a project
+        can't be modified after it's created. It is handled in another
+        part of the code base with a different command. So the user is warned.
+        """
+        if "organization" in kwargs:
+            warnings.warn('Option --organization is not functional.\n'
+                          'Instead, you might want to use either:\n'
+                          '   tower-cli organization associate_project, or\n'
+                          '   tower-cli organization disassociate_project\n'
+                          , UserWarning)
+        return super(Resource, self).modify(*args, **kwargs)
 
     @resources.command(use_fields_as_options=('name', 'organization'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/tests/test_resources_organization.py
+++ b/tests/test_resources_organization.py
@@ -54,7 +54,7 @@ class OrganizationTests(unittest.TestCase):
                              json.dumps({'disassociate': True, 'id': 84}))
 
     def test_project_associate(self):
-        """Test requests for associating project
+        """Test request for associating project with organization.
         """
         with client.test_mode as t:
             t.register_json('/organizations/42/projects/?id=84',
@@ -65,7 +65,7 @@ class OrganizationTests(unittest.TestCase):
                              json.dumps({'associate': True, 'id': 84}))
 
     def test_project_disassociate(self):
-        """Test requests for associating project
+        """Test request for disassociating project with organization.
         """
         with client.test_mode as t:
             t.register_json('/organizations/42/projects/?id=84',

--- a/tests/test_resources_organization.py
+++ b/tests/test_resources_organization.py
@@ -52,3 +52,26 @@ class OrganizationTests(unittest.TestCase):
             self.org_resource.disassociate(42, 84)
             self.assertEqual(t.requests[1].body,
                              json.dumps({'disassociate': True, 'id': 84}))
+
+    def test_project_associate(self):
+        """Test requests for associating project
+        """
+        with client.test_mode as t:
+            t.register_json('/organizations/42/projects/?id=84',
+                            {'count': 0, 'results': []})
+            t.register_json('/organizations/42/projects/', {}, method='POST')
+            self.org_resource.associate_project(42, 84)
+            self.assertEqual(t.requests[1].body,
+                             json.dumps({'associate': True, 'id': 84}))
+
+    def test_project_disassociate(self):
+        """Test requests for associating project
+        """
+        with client.test_mode as t:
+            t.register_json('/organizations/42/projects/?id=84',
+                            {'count': 1, 'results': [{'id': 84}],
+                             'next': None, 'previous': None})
+            t.register_json('/organizations/42/projects/', {}, method='POST')
+            self.org_resource.disassociate_project(42, 84)
+            self.assertEqual(t.requests[1].body,
+                             json.dumps({'disassociate': True, 'id': 84}))

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -26,7 +26,6 @@ from tower_cli.api import client
 from tower_cli.utils import exceptions as exc
 
 from tests.compat import unittest, mock
-import warnings
 
 
 class UpdateTests(unittest.TestCase):
@@ -37,24 +36,27 @@ class UpdateTests(unittest.TestCase):
         self.res = tower_cli.get_resource('project')
 
     def test_create_with_organization(self):
-        """Establish that a project can be created inside of an organization
+        """Establish that a project can be created inside of an organization.
+        This uses the --organization flag with the create command.
+        This action uses the /organizations/{id}/projects/ endpoint
         """
-        org_pk = 1
         with client.test_mode as t:
-            endpoint = '/organizations/%s/projects/' % org_pk
+            endpoint = '/organizations/1/projects/'
             t.register_json(endpoint, {'count': 0, 'results': [],
                             'next': None, 'previous': None},
                             method='GET')
             t.register_json(endpoint, {'changed': True, 'id': 42},
                             method='POST')
-            self.res.create(name='bar', organization=org_pk,
+            self.res.create(name='bar', organization=1,
                             scm_type="git")
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertEqual(t.requests[1].method, 'POST')
             self.assertEqual(len(t.requests), 2)
 
     def test_create_without_organization(self):
-        """Establish that a project can be created without giving an org
+        """Establish that a project can be created without giving an
+        organization. This should create a project with no organization.
+        This action uses the /projects/ endpoint
         """
         with client.test_mode as t:
             endpoint = '/projects/'
@@ -68,29 +70,21 @@ class UpdateTests(unittest.TestCase):
             self.assertEqual(t.requests[1].method, 'POST')
             self.assertEqual(len(t.requests), 2)
 
-    def test_modify_organization_warning(self):
-        """Test that warning is thrown when trying to modify organization
-        because that can not be done in this way.
+    def test_modify_project(self):
+        """Test modifying project in order to cover the special case that
+        removes the organization from its options.
         """
-        org_pk = 1
-        with mock.patch.object(warnings, 'warn') as warn:
-            with client.test_mode as t:
-                t.register_json('/projects/', {'count': 1, 'results': [{'id':1,
-                                'name':'bar'}],
-                                'next': None, 'previous': None},
-                                method='GET')
-                t.register_json('/projects/1/', {'name':'bar', 'id':1,
-                                'type':'project', 'organization':1},
-                                method='GET')
-                t.register_json('/projects/1/', {'name':'bar', 'id':1,
-                                'type':'project', 'organization':1},
-                                method='PATCH')
-                self.res.modify(name='bar', organization=org_pk,
-                                scm_type="git")
-                self.assertEqual(t.requests[0].method, 'GET')
-                self.assertEqual(t.requests[1].method, 'PATCH')
-                self.assertEqual(len(t.requests), 2)
-                warn.assert_called_once_with(mock.ANY, UserWarning)
+        with client.test_mode as t:
+            t.register_json('/projects/', {'count': 1, 'results': [{'id': 1,
+                            'name': 'bar'}], 'next': None, 'previous': None},
+                            method='GET')
+            t.register_json('/projects/1/', {'name': 'bar', 'id': 1,
+                            'type': 'project', 'organization': 1},
+                            method='PATCH')
+            self.res.modify(name='bar', scm_type="git")
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[1].method, 'PATCH')
+            self.assertEqual(len(t.requests), 2)
 
     def test_basic_update(self):
         """Establish that we are able to create a project update

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -35,6 +35,38 @@ class UpdateTests(unittest.TestCase):
     def setUp(self):
         self.res = tower_cli.get_resource('project')
 
+    def test_create_with_organization(self):
+        """Establish that a project can be created inside of an organization
+        """
+        org_pk = 1
+        with client.test_mode as t:
+            endpoint = '/organizations/%s/projects/' % org_pk
+            t.register_json(endpoint, {'count': 0, 'results': [],
+                            'next': None, 'previous': None},
+                            method='GET')
+            t.register_json(endpoint, {'changed': True, 'id': 42},
+                            method='POST')
+            self.res.create(name='bar', organization=org_pk,
+                            scm_type="git")
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[1].method, 'POST')
+            self.assertEqual(len(t.requests), 2)
+
+    def test_create_without_organization(self):
+        """Establish that a project can be created without giving an org
+        """
+        with client.test_mode as t:
+            endpoint = '/projects/'
+            t.register_json(endpoint, {'count': 0, 'results': [],
+                            'next': None, 'previous': None},
+                            method='GET')
+            t.register_json(endpoint, {'changed': True, 'id': 42},
+                            method='POST')
+            self.res.create(name='bar', scm_type="git")
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[1].method, 'POST')
+            self.assertEqual(len(t.requests), 2)
+
     def test_basic_update(self):
         """Establish that we are able to create a project update
         and return the changed status.


### PR DESCRIPTION
The resource model for projects has two extra method added to it. The first of these, create(), solves the problem as expressed in issue #52. The second of these, modify(), raising a warning giving the user notice that the organization can not be set on a pre-existing project with the modify command.

Tower-CLI can not be easily configured to accept lists for arguments, and this is the reason for the state of modifying projects. However, it is understandable that someone would want an ability to modify a project's organization. In order to cover this, I added associate_project and disassociate_project to any organization's commands. This should serve as a complete functional patch for the issue.

Corresponding tests were also written for the different cases. I am seeing 99% on resource.project right now, which I could return to fix. Otherwise, tests are added to maintain coverage of the new code.