### PR TITLE
features added to resolve #35, but warning on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ tower-cli config key value
 By issuing `tower-cli config` with no arguments, you can see a full list
 of configuration options and where they are set.
 
-You will generally need to set at least three configuration options--`host`, 
+You will generally need to set at least three configuration options--`host`,
 `username`, and `password`--which correspond to the location of
 your Ansible Tower instance and your credentials to authenticate to Tower.
 
@@ -81,7 +81,7 @@ $ tower-cli config password myPassw0rd
 
 #### Write to the config files directly.
 
-The configuration file can also be edited directly.  A configuration file is a 
+The configuration file can also be edited directly.  A configuration file is a
 simple file with keys and values, separated by `:` or `=`:
 
 ```yaml
@@ -116,7 +116,7 @@ The "resource" is a type of object within Tower (a noun), such as `user`,
 Tower CLI (so: it's `tower-cli user`, never `tower-cli users`).
 
 The "action" is the thing you want to do (a verb). Most Tower CLI resources
-have the following actions--`get`, `list`, `create`, `modify`, and `delete`--and 
+have the following actions--`get`, `list`, `create`, `modify`, and `delete`--and
 have options corresponding to fields on the object in Tower.
 
 Some examples:
@@ -165,6 +165,22 @@ $ tower-cli # help
 $ tower-cli user --help # resource specific help
 $ tower-cli user create --help # command specific help
 ```
+
+#### SSL
+
+By default tower-cli will warn if the SSL certificate of the Tower server
+can not be verified. To disable this warning, set the config variable
+`verify_ssl` to true. To disable it just for a single command, add the
+--insecure flag.
+
+```bash
+# Disable insecure connection warnings permanently
+$ tower-cli config verify_ssl true
+
+# Disable insecure connection warnings for just this command
+$ tower-cli job_template list --insecure
+```
+
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **tower-cli** is a command line tool for Ansible Tower. It allows Tower
 commands to be easily run from the Unix command line.  It can also be used
-as a client library for other python apps, or as a reference for others 
+as a client library for other python apps, or as a reference for others
 developing API interactions with Tower's REST API.
 
 
@@ -169,13 +169,13 @@ $ tower-cli user create --help # command specific help
 #### SSL
 
 By default tower-cli will warn if the SSL certificate of the Tower server
-can not be verified. To disable this warning, set the config variable
+cannot be verified. To disable this warning, set the config variable
 `verify_ssl` to true. To disable it just for a single command, add the
 --insecure flag.
 
 ```bash
 # Disable insecure connection warnings permanently
-$ tower-cli config verify_ssl true
+$ tower-cli config verify_ssl false
 
 # Disable insecure connection warnings for just this command
 $ tower-cli job_template list --insecure

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -85,6 +85,7 @@ class Settings(object):
             'host': '127.0.0.1',
             'password': '',
             'username': '',
+            'verify_ssl': 'true',
             'verbose': 'false',
         }
         self._defaults = Parser(defaults=defaults)

--- a/lib/tower_cli/utils/decorators.py
+++ b/lib/tower_cli/utils/decorators.py
@@ -44,6 +44,7 @@ def command(method=None, **kwargs):
                 'format': inner_kw.pop('format', None),
                 'username': inner_kw.pop('tower_username', None),
                 'verbose': inner_kw.pop('verbose', None),
+                'insecure': inner_kw.pop('insecure', None),
             }
             with settings.runtime_values(**runtime_settings):
                 return method(*inner_a, **inner_kw)
@@ -101,6 +102,16 @@ def with_global_options(method):
     method = click.option('-v', '--verbose',
         default=None,
         help='Show information about requests being made.',
+        is_flag=True,
+        required=False,
+    )(method)
+
+    # Create a global SSL warning option.
+    method = click.option(
+        '--insecure',
+        default=None,
+        help='Turn off insecure connection warnings. Set config verify_ssl '
+             'to make this permanent.',
         is_flag=True,
         required=False,
     )(method)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,3 +156,14 @@ class ClientTests(unittest.TestCase):
             t.register('/ping/', "I'm a teapot!", status_code=418)
             with self.assertRaises(exc.BadRequest):
                 r = client.get('/ping/')
+
+    def test_disable_connection_warning(self):
+        """Establish that the --insecure flag will cause the program to
+        call disable_warnings in the urllib3 package.
+        """
+        with mock.patch('requests.packages.urllib3.disable_warnings') as g:
+            with client.test_mode as t:
+                t.register('/ping/', "I'm a teapot!", status_code=200)
+                with settings.runtime_values(insecure=False):
+                    client.get('/ping/')
+                    assert g.called


### PR DESCRIPTION
The intent is to give user's the option to disable the insecure https warning, if they choose. 2 ways of doing this are added. You can add an --insecure flag to your command and it will suppress the warning. Or, you can set the config variable verify_ssl to false. The method for the config variable was taken from @wybczu in a removed pull request, https://github.com/ansible/tower-cli/pull/29

My hope is that by maintaining the default (and handling the case where the variable doesn't exist) so that it displays the warning, we still respect the intention that people expressed in previous discussions. It would still be preferable to add the proper CA certificate. A test was added to maintain coverage, but we could do better in the future by testing explicitly that the warnings were or were not thrown in a wide range of use cases.