### PR TITLE
instances of /etc/awx replaced with /etc/tower, resolves #46

### DIFF
--- a/lib/tower_cli/commands/config.py
+++ b/lib/tower_cli/commands/config.py
@@ -48,10 +48,10 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
     """Read or write tower-cli configuration.
 
     `tower config` saves the given setting to the appropriate Tower CLI;
-    either the user's ~/.tower_cli.cfg file, or the /etc/awx/tower_cli.cfg
+    either the user's ~/.tower_cli.cfg file, or the /etc/tower/tower_cli.cfg
     file if --global is used.
 
-    Writing to /etc/awx/tower_cli.cfg is likely to require heightened
+    Writing to /etc/tower/tower_cli.cfg is likely to require heightened
     permissions (in other words, sudo).
     """
     # If the old-style `global_` option is set, issue a deprecation notice.
@@ -73,7 +73,7 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
             'user': 'User options (set with `tower-cli config`; stored in '
                     '~/.tower_cli.cfg).',
             'global': 'Global options (set with `tower-cli config '
-                      '--scope=global`, stored in /etc/awx/tower_cli.cfg).',
+                      '--scope=global`, stored in /etc/tower/tower_cli.cfg).',
             'defaults': 'Defaults.',
         }
 
@@ -129,10 +129,10 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
     # First, we need the appropriate file.
     filename = os.path.expanduser('~/.tower_cli.cfg')
     if scope == 'global':
-        if not os.path.isdir('/etc/awx/'):
-            raise exc.TowerCLIError('/etc/awx/ does not exist, and this '
+        if not os.path.isdir('/etc/tower/'):
+            raise exc.TowerCLIError('/etc/tower/ does not exist, and this '
                                     'command cowardly declines to create it.')
-        filename = '/etc/awx/tower_cli.cfg'
+        filename = '/etc/tower/tower_cli.cfg'
     elif scope == 'local':
         filename = '.tower_cli.cfg'
 

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -64,7 +64,7 @@ class Settings(object):
     The order of precedence for settings, from least to greatest, is:
 
         - defaults provided in this method
-        - `/etc/awx/tower_cli.cfg`
+        - `/etc/tower/tower_cli.cfg`
         - `~/.tower_cli.cfg`
         - command line arguments
 
@@ -93,10 +93,10 @@ class Settings(object):
         # If there is a global settings file, initialize it.
         self._global = Parser()
         self._global.add_section('general')
-        if os.path.isdir('/etc/awx/'):
-            # Sanity check: Try to actually get a list of files in `/etc/awx/`.
+        if os.path.isdir('/etc/tower/'):
+            # Sanity check: Try to actually get a list of files in `/etc/tower/`.
             #
-            # The default Tower installation caused `/etc/awx/` to have
+            # The default Tower installation caused `/etc/tower/` to have
             # extremely restrictive permissions, since it has its own user
             # and group and has a chmod of 0750.
             #
@@ -107,16 +107,16 @@ class Settings(object):
             # Therefore, check for that particular problem and give a warning
             # if we're in that situation.
             try:
-                global_settings = 'tower_cli.cfg' in os.listdir('/etc/awx/')
+                global_settings = 'tower_cli.cfg' in os.listdir('/etc/tower/')
             except OSError:
-                warnings.warn('/etc/awx/ is present, but not readable with '
+                warnings.warn('/etc/tower/ is present, but not readable with '
                               'current permissions. Any settings defined in '
-                              '/etc/awx/tower_cli.cfg will not be honored.',
+                              '/etc/tower/tower_cli.cfg will not be honored.',
                               RuntimeWarning)
 
             # If there is a global settings file for Tower CLI, read in its
             # contents.
-            self._global.read('/etc/awx/tower_cli.cfg')
+            self._global.read('/etc/tower/tower_cli.cfg')
 
         # Initialize a parser for the user settings file.
         self._user = Parser()
@@ -143,7 +143,7 @@ class Settings(object):
 
             # Sanity check: if this directory corresponds to our global or
             # user directory, skip it.
-            if local_dir in (os.path.expanduser('~'), '/etc/awx'):
+            if local_dir in (os.path.expanduser('~'), '/etc/tower'):
                 continue
 
             # Add this directory to the list.

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -113,7 +113,7 @@ class ConfigTests(unittest.TestCase):
         """
         # Invoke the command, but trap the file-write at the end
         # so we don't plow over real things.
-        filename = '/etc/awx/tower_cli.cfg'
+        filename = '/etc/tower/tower_cli.cfg'
         mock_open = mock.mock_open()
         with mock.patch('tower_cli.commands.config.open', mock_open,
                         create=True):
@@ -123,7 +123,7 @@ class ConfigTests(unittest.TestCase):
                     result = self.runner.invoke(
                         config, ['username', 'luke', '--scope=global'],
                     )
-                    isdir.assert_called_once_with('/etc/awx/')
+                    isdir.assert_called_once_with('/etc/tower/')
                     chmod.assert_called_once_with(filename, int('0600', 8))
 
         # Ensure that the command completed successfully.
@@ -132,7 +132,7 @@ class ConfigTests(unittest.TestCase):
                          'Configuration updated successfully.')
 
         # Ensure that the output seems to be correct.
-        self.assertIn(mock.call('/etc/awx/tower_cli.cfg', 'w'),
+        self.assertIn(mock.call('/etc/tower/tower_cli.cfg', 'w'),
                       mock_open.mock_calls)
         self.assertIn(mock.call().write('username = luke\n'),
                       mock_open.mock_calls)
@@ -211,10 +211,10 @@ class ConfigTests(unittest.TestCase):
             isdir.return_value = False
             result = self.runner.invoke(config,
                                         ['host', 'foo', '--scope=global'])
-            isdir.assert_called_once_with('/etc/awx/')
+            isdir.assert_called_once_with('/etc/tower/')
         self.assertEqual(result.exit_code, 1)
         self.assertEqual(result.output.strip(),
-                         'Error: /etc/awx/ does not exist, and this '
+                         'Error: /etc/tower/ does not exist, and this '
                          'command cowardly declines to create it.')
 
 
@@ -264,7 +264,7 @@ class DeprecationTests(unittest.TestCase):
                                                      DeprecationWarning)
                         self.assertEqual(warn.mock_calls[0][1][1],
                                          DeprecationWarning)
-                        isdir.assert_called_once_with('/etc/awx/')
+                        isdir.assert_called_once_with('/etc/tower/')
 
         # Ensure that the command completed successfully.
         self.assertEqual(result.exit_code, 0)
@@ -272,7 +272,7 @@ class DeprecationTests(unittest.TestCase):
                          result.output.strip())
 
         # Ensure that the output seems to be correct.
-        self.assertIn(mock.call('/etc/awx/tower_cli.cfg', 'w'),
+        self.assertIn(mock.call('/etc/tower/tower_cli.cfg', 'w'),
                       mock_open.mock_calls)
         self.assertIn(mock.call().write('username = meagan\n'),
                       mock_open.mock_calls)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -30,7 +30,7 @@ class SettingsTests(unittest.TestCase):
     the way that we expect.
     """
     def test_error_etc_awx(self):
-        """Establish that if /etc/awx/ exists but isn't readable,
+        """Establish that if /etc/tower/ exists but isn't readable,
         that we properly catch it and whine about it.
         """
         with mock.patch.object(os, 'getcwd') as getcwd:
@@ -42,9 +42,9 @@ class SettingsTests(unittest.TestCase):
                         listdir.side_effect = OSError
                         settings = Settings()
                         warn.assert_called_once_with(
-                            '/etc/awx/ is present, but not readable with '
+                            '/etc/tower/ is present, but not readable with '
                             'current permissions. Any settings defined in '
-                            '/etc/awx/tower_cli.cfg will not be honored.',
+                            '/etc/tower/tower_cli.cfg will not be honored.',
                             RuntimeWarning,
                         )
 


### PR DESCRIPTION
Newer versions of tower use /etc/tower instead of /etc/awx. This is only relevant if --scope=global is set to begin with, and if that folder exists. It is a straightforward change. After this, the older version will no longer be supported.