### PR TITLE
upgrade to resolve #64, more types of credentials

### DIFF
--- a/lib/tower_cli/resources/credential.py
+++ b/lib/tower_cli/resources/credential.py
@@ -43,8 +43,21 @@ class Resource(models.Resource):
     # What type of credential is this (machine, SCM, etc.)?
     kind = models.Field(
         help_text='The type of credential being added. '
-                  'Valid options are: ssh, scm, aws, rax, gce, azure.',
-        type=click.Choice(['ssh', 'scm', 'aws', 'rax', 'gce', 'azure']),
+                  'Valid options are: ssh, scm, aws, rax, vmware,'
+                  ' gce, azure, openstack.',
+        type=click.Choice(['ssh', 'scm', 'aws', 'rax', 'vmware',
+                           'gce', 'azure', 'openstack']),
+    )
+
+    # need host in order to use VMware
+    host = models.Field(
+        help_text = 'The hostname or IP address to use.',
+        required = False,
+    )
+    # need project to use openstack
+    project = models.Field(
+        help_text = 'The identifier for the project.',
+        required = False
     )
 
     # SSH and SCM fields.

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -19,7 +19,8 @@ from tower_cli import get_resource, models, resources
 from tower_cli.api import client
 from tower_cli.utils import exceptions as exc, types
 
-INVENTORY_SOURCES = ['manual', 'ec2', 'rax', 'gce', 'azure']
+INVENTORY_SOURCES = ['manual', 'ec2', 'rax', 'vmware',
+                     'gce', 'azure', 'openstack']
 
 
 class Resource(models.Resource):

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -32,7 +32,8 @@ class Resource(models.MonitorableResource):
     source = models.Field(
         default='manual',
         help_text='The type of inventory source in use.',
-        type=click.Choice(['manual', 'ec2', 'rax', 'gce', 'azure']),
+        type=click.Choice(['manual', 'ec2', 'rax', 'vmware',
+                            'gce', 'azure', 'openstack']),
     )
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))


### PR DESCRIPTION
Added 2 options to the list of types of credentials, which were VMware and OpenStack. Adding these also required adding some extra fields, which I believe is also a matter of version changes. More of these types of changes will need to happen to bring tower-cli completely up to speed and resolve some other issues.