### PR TITLE
resolve #54 by updating fields, other fixes

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -65,7 +65,7 @@ class ResourceMeta(type):
 
             # If this method has been overwritten from the superclass, copy
             # any click options or arguments from the superclass implementation
-            # down tot the subclass implementation.
+            # down to the subclass implementation.
             if not len(bases):
                 continue
             superclass = bases[0]

--- a/lib/tower_cli/resources/credential.py
+++ b/lib/tower_cli/resources/credential.py
@@ -51,13 +51,13 @@ class Resource(models.Resource):
 
     # need host in order to use VMware
     host = models.Field(
-        help_text = 'The hostname or IP address to use.',
-        required = False,
+        help_text='The hostname or IP address to use.',
+        required=False,
     )
     # need project to use openstack
     project = models.Field(
-        help_text = 'The identifier for the project.',
-        required = False
+        help_text='The identifier for the project.',
+        required=False
     )
 
     # SSH and SCM fields.
@@ -71,17 +71,31 @@ class Resource(models.Resource):
         password=True,
         required=False,
     )
-    private_key = models.Field('ssh_key_data',
+    ssh_key_data = models.Field(
+        'ssh_key_data',
         display=False,
         help_text="The full path to the SSH private key to store. "
                   "(Don't worry; it's encrypted.)",
         required=False,
         type=models.File('r'),
     )
-    private_key_password = models.Field('ssh_key_unlock', password=True,
-                                                          required=False)
+    ssh_key_unlock = models.Field('ssh_key_unlock', password=True,
+                                  required=False)
+
+    # Method with which to esclate
+    become_method = models.Field(
+        help_text='Privledge escalation method. ',
+        type=types.MappedChoice([
+            ('', 'None'),
+            ('sudo', 'sudo'),
+            ('su', 'su'),
+            ('pbrun', 'pbrun'),
+            ('pfexec', 'pfexec'),
+        ]),
+        required=False,
+    )
 
     # SSH specific fields.
-    sudo_username = models.Field(required=False, display=False)
-    sudo_password = models.Field(password=True, required=False)
+    become_username = models.Field(required=False, display=False)
+    become_password = models.Field(password=True, required=False)
     vault_password = models.Field(password=True, required=False)

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -51,7 +51,10 @@ class Resource(models.Resource):
             (1, 'verbose'),
             (2, 'debug'),
         ]),
+        required=False,
     )
     job_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(type=models.File('r'), required=False,
                               display=False)
+    become_enabled = models.Field(type=bool, required=False,
+                                  show_default=True, default=False)

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -53,8 +53,10 @@ class Resource(models.MonitorableResource):
     scm_update_on_launch = models.Field(type=bool, required=False,
                                         display=False)
 
+    @resources.command
     def create(self, *args, **kwargs):
-        """Fix for issue #52, second method, replacing the /projects/
+        """Create a project, with or w/o org.
+        Fix for issue #52, second method, replacing the /projects/
         endpoint temporarily if the project has an organization specified
         """
         if "organization" in kwargs:
@@ -72,7 +74,8 @@ class Resource(models.MonitorableResource):
         'scm_update_on_launch'
     ))
     def modify(self, *args, **kwargs):
-        """Also associated with issue #52, the organization can't be modified
+        """Modify a project, see org help to modify org.
+        Also associated with issue #52, the organization can't be modified
         with the 'modify' command. This would create confusion about whether
         it served the role of an identifier versus a field to modify. This
         method is used to set the allowed fields on the modify command,


### PR DESCRIPTION
This update allows the use of the become_username, become_password, and other fields that allow privilege escalation by becoming another user through the su command, and others. This has been manually tested to the point of launching new jobs with an su-type privilege escalation.

In addition to that, the @resources.command decorator is added on the project create method overriding the generic resource version. This is a fix for a problem that a previous commit of mine created, which caused tower-cli to crash when creating a job template.