### PR TITLE
Merge with existing variables (instead of clobber)

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -77,7 +77,7 @@ class Resource(models.MonitorableResource):
         if extra_vars:
             if hasattr(extra_vars, 'read'):
                 extra_vars = extra_vars.read()
-            data['extra_vars'] = extra_vars
+            data['extra_vars'] = data['extra_vars']+extra_vars
         elif data.pop('ask_variables_on_launch', False) and not no_input:
             initial = data['extra_vars']
             initial = '\n'.join((


### PR DESCRIPTION
Currently, if `--extra-vars=filename` is used with `job launch` , any existing `extra-vars` defined in the job template are ignored and only the ones defined in the file are used. This makes it very hard to automate answering surveys via tower-cli (e.g. filling in a variable).

I think merging together the 2 sets of extra-vars is more expected behaviour and allows more use-cases to work.

---

    $tower-cli version
    Ansible Tower 2.2.0
    Tower CLI 2.1.1

    $ansible --version
    ansible 1.9.1
