### PR TITLE
add skip-tags to JT resource, fix parser bug

### DIFF
--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -56,6 +56,7 @@ class Resource(models.Resource):
         required=False,
     )
     job_tags = models.Field(required=False, display=False)
+    skip_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(required=False, display=False)
     become_enabled = models.Field(type=bool, required=False, display=False,
                                   show_default=True, default=False)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -100,7 +100,7 @@ def string_to_dict(var_string):
 def file_or_yaml_split(extra_vars_opt):
     """If the input text starts with @, then it is treated as a file name
     and the contents of the file are returned."""
-    if extra_vars_opt.startswith("@"):
+    if extra_vars_opt and extra_vars_opt.startswith("@"):
         # Argument is a file with variables in it, so return its content
         with open(extra_vars_opt[1:], 'r') as f:
             filetext = f.read()


### PR DESCRIPTION
recent parser change assumed extra-vars was always specified, bombs when it wasn't

cc @AlanCoding 