### PR TITLE
handle more edge cases, update tests

### DIFF
--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -29,6 +29,9 @@ def parse_kv(var_string):
     but not as fully featured as the corresponding Ansible code."""
     return_dict = {}
 
+    if var_string is None:
+        return {}
+
     # Python 2.6 / shlex has problems handling unicode, this is a fix
     fix_encoding_26 = False
     if sys.version_info < (2, 7) and '\x00' in shlex.split(u'a')[0]:
@@ -80,12 +83,12 @@ def string_to_dict(var_string):
         # Accept all valid "key":value types of json
         return_dict = json.loads(var_string)
         assert type(return_dict) is dict
-    except (AttributeError, ValueError, AssertionError):
+    except (TypeError, AttributeError, ValueError, AssertionError):
         try:
             # Accept all valid key: value types of yaml
             return_dict = yaml.load(var_string)
             assert type(return_dict) is dict
-        except (yaml.YAMLError, AssertionError):
+        except (AttributeError, yaml.YAMLError, AssertionError):
             # if these fail, parse by key=value syntax
             try:
                 return_dict = parse_kv(var_string)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -29,14 +29,18 @@ def parse_kv(var_string):
     but not as fully featured as the corresponding Ansible code."""
     return_dict = {}
 
+    # Output updates dictionaries, so return empty one if no vals in
     if var_string is None:
         return {}
 
     # Python 2.6 / shlex has problems handling unicode, this is a fix
     fix_encoding_26 = False
     if sys.version_info < (2, 7) and '\x00' in shlex.split(u'a')[0]:
-        var_string = str(var_string)
         fix_encoding_26 = True
+
+    # Also hedge against Click library giving non-string type
+    if fix_encoding_26 or not isinstance(var_string, str):
+        var_string = str(var_string)
 
     # Use shlex library to split string by quotes, whitespace, etc.
     for token in shlex.split(var_string):

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -88,7 +88,7 @@ class ParserTests(unittest.TestCase):
 
     def test_handling_bad_data(self):
         """Check robustness of the parser functions in how it handles
-        empty strings and null values."""
+        empty strings, null values, etc."""
         # Verrify that all parts of the computational chain can handle None
         return_dict = parser.parse_kv(None)
         self.assertEqual(return_dict, {})
@@ -104,6 +104,12 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(return_dict, {})
         return_val = parser.file_or_yaml_split("")
         self.assertEqual(return_val, "")
+
+        # Check that the behavior is what we want if feeding it an int
+        return_dict = parser.parse_kv(5)
+        self.assertEqual(return_dict, {"_raw_params": "5"})
+        return_dict = parser.parse_kv("foo=5")
+        self.assertEqual(return_dict, {"foo": 5})
 
 
 class TestSplitter_Gen(unittest.TestCase):

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -86,6 +86,25 @@ class ParserTests(unittest.TestCase):
         with self.assertRaises(exc.TowerCLIError):
             parser.extra_vars_loader_wrapper(["a: b\nincorrect = =brackets"])
 
+    def test_handling_bad_data(self):
+        """Check robustness of the parser functions in how it handles
+        empty strings and null values."""
+        # Verrify that all parts of the computational chain can handle None
+        return_dict = parser.parse_kv(None)
+        self.assertEqual(return_dict, {})
+        return_dict = parser.string_to_dict(None)
+        self.assertEqual(return_dict, {})
+        return_val = parser.file_or_yaml_split(None)
+        self.assertEqual(return_val, None)
+
+        # Verrify that all parts of computational chain can handle ""
+        return_dict = parser.parse_kv("")
+        self.assertEqual(return_dict, {})
+        return_dict = parser.string_to_dict("")
+        self.assertEqual(return_dict, {})
+        return_val = parser.file_or_yaml_split("")
+        self.assertEqual(return_val, "")
+
 
 class TestSplitter_Gen(unittest.TestCase):
     """Set of strings paired with expected output is ran agains the parsing


### PR DESCRIPTION
Tests were added to broadly cover null values and empty strings in the parser functions. It turned out that the current parser utility would not pass those, so more changes were made in order to have them all passing. @nitzmahone, if you wouldn't mind, could you take a look at what was done here and see if anything else needs to be changed?