### PR TITLE
Added more "inventory source" variables on group create / modify

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ $ tower-cli user get --username=guido
 
 # Create a new user.
 $ tower-cli user create --username=guido --first-name=Guido \
-                        --last-name="Van Rossum" --email=guido@python.org
+                        --last-name="Van Rossum" --email=guido@python.org \
+                        --password=password1234
 
 # Modify an existing user.
 # This would modify the first name of the user with the ID of "42" to "Guido".
@@ -214,6 +215,13 @@ $ tower-cli config verify_ssl false
 $ tower-cli job_template list --insecure
 ```
 
+#### Bash script example
+
+If you want an example for a particular case that this README does not cover,
+the development distribution of tower-cli includes a script that will
+populate the Tower server with fake data using tower-cli commands. These
+attempt to cover most of the available features. These can be found in
+the folder [/docs/examples/](/docs/examples).
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -215,14 +215,6 @@ $ tower-cli config verify_ssl false
 $ tower-cli job_template list --insecure
 ```
 
-#### Bash script example
-
-If you want an example for a particular case that this README does not cover,
-the development distribution of tower-cli includes a script that will
-populate the Tower server with fake data using tower-cli commands. These
-attempt to cover most of the available features. These can be found in
-the folder [/docs/examples/](/docs/examples).
-
 ### License
 
 While Tower is commercially licensed software, _tower-cli_ is an open source project,

--- a/lib/tower_cli/models/__init__.py
+++ b/lib/tower_cli/models/__init__.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from tower_cli.models.base import BaseResource, ReadableResource, \
-                                  WritableResource, MonitorableResource
+                                  WritableResource, MonitorableResource, \
+                                  ExeResource
 from tower_cli.models.fields import Field
 from tower_cli.utils.types import File

--- a/lib/tower_cli/models/__init__.py
+++ b/lib/tower_cli/models/__init__.py
@@ -12,9 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# flake8: noqa
 
-from __future__ import absolute_import, unicode_literals  # NOQA
+from __future__ import absolute_import, unicode_literals
 
-from tower_cli.models.base import BaseResource, Resource, MonitorableResource  # NOQA
-from tower_cli.models.fields import Field  # NOQA
-from tower_cli.utils.types import File  # NOQA
+from tower_cli.models.base import BaseResource, ReadableResource, \
+                                  WritableResource, MonitorableResource
+from tower_cli.models.fields import Field
+from tower_cli.utils.types import File

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -920,8 +920,13 @@ class MonitorableResource(ReadableResource):
                 secho('\r' + ' ' * longest_string, file=outfile, nl=False)
                 secho('\r', file=outfile, nl=False)
 
-        # Done; return the result
-        return result
+        # Return the job ID and other response data
+        answer = OrderedDict((
+            ('changed', True),
+            ('id', pk),
+        ))
+        answer.update(result)
+        return answer
 
 
 class ExeResource(MonitorableResource):

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -22,12 +22,13 @@ from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
 
 
-class Resource(models.ReadableResource, models.ExeResource):
+class Resource(models.ExeResource):
     """A resource for ad hoc commands."""
     cli_help = 'Launch commands based on playbook given at runtime.'
     endpoint = '/ad_hoc_commands/'
 
     # Parameters similar to job
+    name = models.Field(unique=True)
     job_explanation = models.Field(required=False, display=False)
     created = models.Field(required=False, display=True)
     status = models.Field(required=False, display=True)
@@ -93,7 +94,7 @@ class Resource(models.ReadableResource, models.ExeResource):
 
         # Pop the None arguments because we have no .write() method in
         # inheritance chain for this type of resource. This is needed
-        super(Resource, self)._pop_none(kwargs)
+        self._pop_none(kwargs)
 
         # Actually start the job.
         debug.log('Launching the ad-hoc command.', header='details')

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -63,7 +63,6 @@ class Resource(models.ExeResource):
         ]),
         required=False,
     )
-    become_enabled = models.Field(type=bool, required=False, display=False)
 
     @resources.command(
         use_fields_as_options=(
@@ -79,7 +78,10 @@ class Resource(models.ExeResource):
                   help='If provided with --monitor, this attempt'
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
-    def launch(self, monitor=False, timeout=None, **kwargs):
+    @click.option('--become', required=False, is_flag=True,
+                  help='If used, privledge escalation will be enabled for '
+                       'this command.')
+    def launch(self, monitor=False, timeout=None, become=False, **kwargs):
         """Launch a new ad-hoc command.
 
         Runs a user-defined command from Ansible Tower, immediately starts it,
@@ -95,6 +97,10 @@ class Resource(models.ExeResource):
         # Pop the None arguments because we have no .write() method in
         # inheritance chain for this type of resource. This is needed
         self._pop_none(kwargs)
+
+        # Change the flag to the dictionary format
+        if become:
+            kwargs['become_enabled'] = True
 
         # Actually start the job.
         debug.log('Launching the ad-hoc command.', header='details')

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -20,6 +20,7 @@ import click
 from tower_cli import models, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
+from tower_cli.utils.data_structures import OrderedDict
 
 
 class Resource(models.ExeResource):
@@ -28,7 +29,6 @@ class Resource(models.ExeResource):
     endpoint = '/ad_hoc_commands/'
 
     # Parameters similar to job
-    name = models.Field(unique=True)
     job_explanation = models.Field(required=False, display=False)
     created = models.Field(required=False, display=True)
     status = models.Field(required=False, display=True)
@@ -53,7 +53,7 @@ class Resource(models.ExeResource):
                                default="command", show_default=True)
     module_args = models.Field(required=False, display=False)
     forks = models.Field(type=int, required=False, display=False)
-    limit = models.Field(required=False, display=True)
+    limit = models.Field(required=False, display=False)
     verbosity = models.Field(
         display=False,
         type=types.MappedChoice([
@@ -107,8 +107,10 @@ class Resource(models.ExeResource):
         if monitor:
             return self.monitor(job_id, timeout=timeout)
 
-        # Return the job ID.
-        return {
-            'changed': True,
-            'id': job_id,
-        }
+        # Return the job ID and other response data
+        answer = OrderedDict((
+            ('changed', True),
+            ('id', job_id),
+        ))
+        answer.update(result.json())
+        return answer

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -1,0 +1,146 @@
+# Copyright 2015, Ansible, Inc.
+# Luke Sneeringer <lsneeringer@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, unicode_literals
+from distutils.version import LooseVersion
+
+import click
+
+from sdict import adict
+
+from tower_cli import models, resources
+from tower_cli.api import client
+from tower_cli.utils import debug, exceptions as exc, types
+
+
+class Resource(models.ReadableResource, models.MonitorableResource):
+    """A resource for ad hoc commands."""
+    cli_help = 'Launch or monitor  without template.'
+    endpoint = '/ad_hoc_commands/'
+
+    # Many parameter fields are similiar to job template, as opposed to job
+    job_type = models.Field(
+        default='run',
+        display=False,
+        show_default=True,
+        type=click.Choice(['run', 'check']),
+    )
+    inventory = models.Field(type=types.Related('inventory'))
+    machine_credential = models.Field(
+        'credential',
+        display=False,
+        type=types.Related('credential'),
+    )
+    cloud_credential = models.Field(type=types.Related('credential'),
+                                    required=False, display=False)
+    module_name = models.Field(required=False, display=False,
+                               default="command")
+    module_args = models.Field(required=False, display=False, default="")
+    forks = models.Field(type=int, default=0, required=False, display=False)
+    limit = models.Field(required=False, display=False, default="")
+    verbosity = models.Field(
+        default="default",
+        display=False,
+        type=types.MappedChoice([
+            (0, 'default'),
+            (1, 'verbose'),
+            (2, 'debug'),
+        ]),
+        required=False,
+    )
+    become_enabled = models.Field(type=bool, required=False, display=False,
+                                  show_default=True, default=False)
+
+    @resources.command
+    @click.option('--monitor', is_flag=True, default=False,
+                  help='If sent, immediately calls `job monitor` on the newly '
+                       'launched job rather than exiting with a success.')
+    @click.option('--timeout', required=False, type=int,
+                  help='If provided with --monitor, this command (not the job)'
+                       ' will time out after the given number of seconds. '
+                       'Does nothing if --monitor is not sent.')
+    def launch(self, monitor=False, timeout=None, **kwargs):
+        """Launch a new job based on ad-hoc tasks.
+
+        Creates a new job in Ansible Tower, immediately starts it, and
+        returns back an ID in order for its status to be monitored.
+        """
+        # This feature only exists for versions 2.2 and up
+        r = client.get('/config/')
+        if LooseVersion(r.json()['version']) < LooseVersion('2.2'):
+            raise exc.TowerCLIError('Your host is running an outdated version'
+                                    'of Ansible Tower that can not run '
+                                    'ad-hoc commands')
+
+        # Actually start the job.
+        debug.log('Launching the ad-hoc job.', header='details')
+        result = client.post(self.endpoint, data=kwargs)
+        job = result.json()
+        job_id = job['id']
+
+        # If we were told to monitor the job once it started, then call
+        # monitor from here.
+        if monitor:
+            return self.monitor(job_id, timeout=timeout)
+
+        # Return the job ID.
+        return {
+            'changed': True,
+            'id': job_id,
+        }
+
+    @resources.command
+    @click.option('--detail', is_flag=True, default=False,
+                  help='Print more detail.')
+    def status(self, pk, detail=False):
+        """Print the current job status."""
+        # Get the job from Ansible Tower.
+        debug.log('Asking for ad-hoc job status.', header='details')
+        finished_endpoint = self.endpoint + str(pk) + "/"
+        job = client.get(finished_endpoint).json()
+
+        # In most cases, we probably only want to know the status of the job
+        # and the amount of time elapsed. However, if we were asked for
+        # verbose information, provide it.
+        if detail:
+            return job
+
+        # Print just the information we need.
+        return adict({
+            'elapsed': job['elapsed'],
+            'failed': job['failed'],
+            'status': job['status'],
+        })
+
+    @resources.command
+    @click.option('--fail-if-not-running', is_flag=True, default=False,
+                  help='Fail loudly if the job is not currently running.')
+    def cancel(self, pk, fail_if_not_running=False):
+        """Cancel a currently running job.
+
+        Fails with a non-zero exit status if the job cannot be canceled.
+        """
+        cancel_endpoint = self.endpoint + str(pk) + "/cancel/"
+        # Attempt to cancel the job.
+        try:
+            client.post(cancel_endpoint)
+            changed = True
+        except exc.MethodNotAllowed:
+            changed = False
+            if fail_if_not_running:
+                raise exc.TowerCLIError('Job not running.')
+
+        # Return a success.
+        return adict({'status': 'canceled', 'changed': changed})

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/tower_cli/resources/credential.py
+++ b/lib/tower_cli/resources/credential.py
@@ -34,13 +34,14 @@ class Resource(models.WritableResource):
         required=False,
     )
     team = models.Field(
-        display=False,
+        display=True,
         type=types.Related('team'),
         required=False,
     )
 
     # What type of credential is this (machine, SCM, etc.)?
     kind = models.Field(
+        display=True,
         help_text='The type of credential being added. '
                   'Valid options are: ssh, scm, aws, rax, vmware,'
                   ' gce, azure, openstack.',
@@ -51,12 +52,12 @@ class Resource(models.WritableResource):
     # need host in order to use VMware
     host = models.Field(
         help_text='The hostname or IP address to use.',
-        required=False,
+        required=False, display=False
     )
     # need project to use openstack
     project = models.Field(
         help_text='The identifier for the project.',
-        required=False
+        required=False, display=False
     )
 
     # SSH and SCM fields.

--- a/lib/tower_cli/resources/credential.py
+++ b/lib/tower_cli/resources/credential.py
@@ -19,7 +19,7 @@ from tower_cli import models
 from tower_cli.utils import types
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage credentials within Ansible Tower.'
     endpoint = '/credentials/'
     identity = ('user', 'team', 'kind', 'name')

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -23,7 +23,7 @@ INVENTORY_SOURCES = ['manual', 'ec2', 'rax', 'vmware',
                      'gce', 'azure', 'openstack']
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage groups belonging to an inventory.'
     endpoint = '/groups/'
     identity = ('inventory', 'name')

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -34,12 +34,24 @@ class Resource(models.WritableResource):
     variables = models.Field(type=types.File('r'), required=False,
                              display=False)
 
+    # Basic options for the source
     @click.option('--credential', type=types.Related('credential'),
                   required=False,
                   help='The cloud credential to use.')
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def create(self, credential=None, source=None, **kwargs):
         """Create a group and, if necessary, modify the inventory source within
         the group.
@@ -75,6 +87,17 @@ class Resource(models.WritableResource):
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def modify(self, pk=None, credential=None, source=None, **kwargs):
         """Modify a group and, if necessary, the inventory source within
         the group.

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -19,7 +19,7 @@ from tower_cli import models, resources
 from tower_cli.utils import types
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage hosts belonging to a group within an inventory.'
     endpoint = '/hosts/'
     identity = ('inventory', 'name')

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -17,7 +17,7 @@ from tower_cli import models
 from tower_cli.utils import types
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage inventory within Ansible Tower.'
     endpoint = '/inventories/'
     identity = ('organization', 'name')

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -34,6 +34,16 @@ class Resource(models.MonitorableResource, models.WritableResource):
         type=click.Choice(['manual', 'ec2', 'rax', 'vmware',
                            'gce', 'azure', 'openstack']),
     )
+    source_regions = models.Field(required=False, display=False)
+    # Variables not shared by all cloud providers
+    source_vars = models.Field(required=False, display=False)
+    # Boolean variables
+    overwrite = models.Field(type=bool, required=False, display=False)
+    overwrite_vars = models.Field(type=bool, required=False, display=False)
+    update_on_launch = models.Field(type=bool, required=False, display=False)
+    # Only used if update_on_launch is used
+    update_cache_timeout = models.Field(type=int, required=False,
+                                        display=False)
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -22,7 +22,7 @@ from tower_cli.api import client
 from tower_cli.utils import debug, types, exceptions as exc
 
 
-class Resource(models.WritableResource, models.MonitorableResource):
+class Resource(models.MonitorableResource, models.WritableResource):
     cli_help = 'Manage inventory sources within Ansible Tower.'
     endpoint = '/inventory_sources/'
     internal = True

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -22,7 +22,7 @@ from tower_cli.api import client
 from tower_cli.utils import debug, types, exceptions as exc
 
 
-class Resource(models.MonitorableResource):
+class Resource(models.WritableResource, models.MonitorableResource):
     cli_help = 'Manage inventory sources within Ansible Tower.'
     endpoint = '/inventory_sources/'
     internal = True

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -28,11 +28,12 @@ from tower_cli.utils import debug, exceptions as exc, types
 from tower_cli.utils import parser
 
 
-class Resource(models.MonitorableResource):
+class Resource(models.ReadableResource, models.MonitorableResource):
     """A resource for jobs.
 
-    As a base resource, this resource does *not* have the normal create, list,
-    etc. methods.
+    This resource has ordinary list and get methods,
+    but it does not have create or modify.
+    Instead of being created, a job is launched.
     """
     cli_help = 'Launch or monitor jobs.'
     endpoint = '/jobs/'

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -75,7 +75,7 @@ class Resource(models.WritableResource):
         return super(Resource, self).create(*args, **kwargs)
 
     @resources.command
-    def modify(self, *args, **kwargs):
+    def modify(self, pk=None, *args, **kwargs):
         """Modify a job template.
         You may only include one --extra-vars flag with this command, and
         whatever you provde will overwrite the existing field. Start this
@@ -84,4 +84,4 @@ class Resource(models.WritableResource):
             # read from file, if given
             kwargs['extra_vars'] = \
                 parser.file_or_yaml_split(kwargs['extra_vars'])
-        return super(Resource, self).modify(*args, **kwargs)
+        return super(Resource, self).modify(pk=pk, *args, **kwargs)

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -58,8 +58,7 @@ class Resource(models.WritableResource):
     job_tags = models.Field(required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(required=False, display=False)
-    become_enabled = models.Field(type=bool, required=False, display=False,
-                                  show_default=True, default=False)
+    become_enabled = models.Field(type=bool, required=False, display=False)
 
     @resources.command
     @click.option('--extra-vars', required=False, multiple=True,

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -22,7 +22,7 @@ from tower_cli.utils import types
 from tower_cli.utils import parser
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage job templates.'
     endpoint = '/job_templates/'
 

--- a/lib/tower_cli/resources/organization.py
+++ b/lib/tower_cli/resources/organization.py
@@ -19,7 +19,7 @@ from tower_cli import models, resources
 from tower_cli.utils import types
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage organizations within Ansible Tower.'
     endpoint = '/organizations/'
 

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -22,7 +22,7 @@ from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
 
 
-class Resource(models.MonitorableResource):
+class Resource(models.WritableResource, models.MonitorableResource):
     cli_help = 'Manage projects within Ansible Tower.'
     endpoint = '/projects/'
 

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -17,12 +17,12 @@ import click
 
 from sdict import adict
 
-from tower_cli import models, resources
+from tower_cli import models, get_resource, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
 
 
-class Resource(models.WritableResource, models.MonitorableResource):
+class Resource(models.MonitorableResource, models.WritableResource):
     cli_help = 'Manage projects within Ansible Tower.'
     endpoint = '/projects/'
 
@@ -53,27 +53,48 @@ class Resource(models.WritableResource, models.MonitorableResource):
     scm_update_on_launch = models.Field(type=bool, required=False,
                                         display=False)
 
+    @click.option('--monitor', is_flag=True, default=False,
+                  help='If sent, immediately calls `project monitor` on the '
+                       'project rather than exiting with a success.'
+                       'It polls for status until the SCM is updated.')
+    @click.option('--timeout', required=False, type=int,
+                  help='If provided with --monitor, the SCM update'
+                       ' will time out after the given number of seconds. '
+                       'Does nothing if --monitor is not sent.')
     @resources.command
-    def create(self, *args, **kwargs):
-        """Create a project, with or w/o org.
-        Fix for issue #52, second method, replacing the /projects/
-        endpoint temporarily if the project has an organization specified
+    def create(self, organization=None, monitor=False, timeout=None,
+               *args, **kwargs):
+        """Create a new item of resource, with or w/o org.
+        This would be a shared class with user, but it needs the ability
+        to monitor if the flag is set.
         """
-        if "organization" in kwargs:
-            debug.log("using alternative endpoint for new project",
+        backup_endpoint = self.endpoint
+        if organization:
+            debug.log("using alternative endpoint specific to organization",
                       header='details')
-            org_pk = kwargs['organization']
-            self.endpoint = '/organizations/%s/projects/' % org_pk
-        to_return = super(Resource, self).create(*args, **kwargs)
-        self.endpoint = '/projects/'
-        return to_return
+
+            # Get the organization from Tower, will lookup name if needed
+            org_resource = get_resource('organization')
+            org_data = org_resource.get(organization)
+            org_pk = org_data['id']
+
+            self.endpoint = '/organizations/%s%s' % (org_pk, backup_endpoint)
+        answer = super(Resource, self).create(*args, **kwargs)
+        self.endpoint = backup_endpoint
+
+        # if the monitor flag is set, wait for the SCM to update
+        if monitor:
+            project_id = answer['id']
+            return self.monitor(project_id, timeout=timeout)
+
+        return answer
 
     @resources.command(use_fields_as_options=(
         'name', 'description', 'scm_type', 'scm_url', 'local_path',
         'scm_branch', 'scm_credential', 'scm_clean', 'scm_delete_on_update',
         'scm_update_on_launch'
     ))
-    def modify(self, *args, **kwargs):
+    def modify(self, pk=None, *args, **kwargs):
         """Modify a project, see org help to modify org.
         Also associated with issue #52, the organization can't be modified
         with the 'modify' command. This would create confusion about whether
@@ -81,7 +102,7 @@ class Resource(models.WritableResource, models.MonitorableResource):
         method is used to set the allowed fields on the modify command,
         removing the organization from available options.
         """
-        return super(Resource, self).modify(*args, **kwargs)
+        return super(Resource, self).modify(pk=pk, *args, **kwargs)
 
     @resources.command(use_fields_as_options=('name', 'organization'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/lib/tower_cli/resources/team.py
+++ b/lib/tower_cli/resources/team.py
@@ -19,7 +19,7 @@ from tower_cli import models, resources
 from tower_cli.utils import types
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage teams within Ansible Tower.'
     endpoint = '/teams/'
     identity = ('organization', 'name')

--- a/lib/tower_cli/resources/user.py
+++ b/lib/tower_cli/resources/user.py
@@ -16,7 +16,7 @@
 from tower_cli import models
 
 
-class Resource(models.Resource):
+class Resource(models.WritableResource):
     cli_help = 'Manage users within Ansible Tower.'
     endpoint = '/users/'
     identity = ('username',)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -73,7 +73,7 @@ class ResourceMetaTests(unittest.TestCase):
         on classes inherited from Resource.
         """
         # Create the resource.
-        class MyResource(models.Resource):
+        class MyResource(models.WritableResource):
             endpoint = '/bogus/'
 
         # Establish it has the commands we expect.
@@ -85,7 +85,7 @@ class ResourceMetaTests(unittest.TestCase):
         superclass implementation options.
         """
         # Create the subclass resource, overriding a superclass command.
-        class MyResource(models.Resource):
+        class MyResource(models.WritableResource):
             endpoint = '/bogus/'
 
             @resources.command
@@ -102,7 +102,7 @@ class ResourceMetaTests(unittest.TestCase):
         the resource.
         """
         # Create the resource.
-        class MyResource(models.Resource):
+        class MyResource(models.WritableResource):
             endpoint = '/bogus/'
 
             foo = models.Field(unique=True)
@@ -123,14 +123,14 @@ class ResourceMetaTests(unittest.TestCase):
         raises TypeError.
         """
         with self.assertRaises(TypeError):
-            class MyResource(models.Resource):
+            class MyResource(models.WritableResource):
                 pass
 
     def test_endpoint_normalization(self):
         """Establish that the endpoints have leading and trailing slashes
         added if they are not present on a resource.
         """
-        class MyResource(models.Resource):
+        class MyResource(models.WritableResource):
             endpoint = 'foo'
         self.assertEqual(MyResource.endpoint, '/foo/')
 
@@ -143,7 +143,7 @@ class SubcommandTests(unittest.TestCase):
         """Install a resource instance sufficient for testing common
         things with subcommands.
         """
-        class BasicResource(models.Resource):
+        class BasicResource(models.WritableResource):
             endpoint = '/basic/'
             name = models.Field(unique=True)
         self.resource = BasicResource()
@@ -256,7 +256,7 @@ class SubcommandTests(unittest.TestCase):
         """
         # Create a resource with a field that is an option and another
         # field that isn't.
-        class NoOptionResource(models.Resource):
+        class NoOptionResource(models.WritableResource):
             endpoint = '/nor/'
 
             yes = models.Field()
@@ -275,7 +275,7 @@ class SubcommandTests(unittest.TestCase):
         key is used for the field name instead of the implicit name.
         """
         # Create a resource with a field that has an explicit key.
-        class ExplicitKeyResource(models.Resource):
+        class ExplicitKeyResource(models.WritableResource):
             endpoint = '/ekr/'
 
             option_name = models.Field('internal_name')
@@ -295,7 +295,7 @@ class SubcommandTests(unittest.TestCase):
         that the automatic docstring replacement is gramatically correct.
         """
         # Create a resource with an approriate name.
-        class Oreo(models.Resource):
+        class Oreo(models.WritableResource):
             resource_name = 'Oreo cookie'   # COOOOOOKIES!!!!
             endpoint = '/oreo/'
 
@@ -308,7 +308,7 @@ class SubcommandTests(unittest.TestCase):
         replacement is correct.
         """
         # Create a resource with an approriate name.
-        class Oreo(models.Resource):
+        class Oreo(models.WritableResource):
             resource_name = 'telephony'
             endpoint = '/telephonies/'
 
@@ -458,7 +458,7 @@ class ResourceTests(unittest.TestCase):
     def setUp(self):
         # Create a resource class that can be used across this particular
         # suite.
-        class FooResource(models.Resource):
+        class FooResource(models.WritableResource):
             endpoint = '/foo/'
             name = models.Field(unique=True)
             description = models.Field(required=False)
@@ -650,7 +650,7 @@ class ResourceTests(unittest.TestCase):
         """
         # Create a resource with a required field that isn't the name
         # field.
-        class BarResource(models.Resource):
+        class BarResource(models.WritableResource):
             endpoint = '/bar/'
             name = models.Field(unique=True)
             required = models.Field()

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -32,7 +32,9 @@ class LaunchTests(unittest.TestCase):
         """
         with client.test_mode as t:
             t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
-            t.register_json('/config/', {'version': '2.2.0'}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
             t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
             result = self.res.launch(inventory=1, machine_credential=2,
                                      module_args="echo 'hi'")
@@ -44,7 +46,7 @@ class LaunchTests(unittest.TestCase):
         """
         with client.test_mode as t:
             t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
-            t.register_json('/config/', {'version': '2.1.0'}, method='GET')
+            t.register_json('/', {}, method='GET')
             t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
             with self.assertRaises(exc.TowerCLIError):
                 self.res.launch(inventory=1, machine_credential=2,
@@ -56,7 +58,9 @@ class LaunchTests(unittest.TestCase):
         """
         with client.test_mode as t:
             t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
-            t.register_json('/config/', {'version': '2.3.0'}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
             t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
 
             with mock.patch.object(type(self.res), 'monitor') as monitor:

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -1,0 +1,139 @@
+# Copyright 2015, Ansible, Inc.
+# Luke Sneeringer <lsneeringer@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+from tower_cli.utils import exceptions as exc
+
+from tests.compat import unittest, mock
+
+
+class LaunchTests(unittest.TestCase):
+    """A set of tests for ensuring that the ad hoc resource's
+    launch command works in the way we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_basic_launch(self):
+        """Establish that we are able to create a ad hoc job.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/config/', {'version': '2.2.0'}, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            result = self.res.launch(inventory=1, machine_credential=2,
+                                     module_args="echo 'hi'")
+            self.assertEqual(result, {'changed': True, 'id': 42})
+
+    def test_version_failure(self):
+        """Establish that if the job has failed, that we raise the
+        JobFailure exception.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/config/', {'version': '2.1.0'}, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            with self.assertRaises(exc.TowerCLIError):
+                self.res.launch(inventory=1, machine_credential=2,
+                                module_args="echo 'hi'")
+
+    def test_basic_launch_monitor_option(self):
+        """Establish that we are able to create a job that doesn't require
+        any invocation-time input, and that monitor is called if requested.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/config/', {'version': '2.3.0'}, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+
+            with mock.patch.object(type(self.res), 'monitor') as monitor:
+                self.res.launch(inventory=1, machine_credential=2,
+                                module_args="echo 'hi'", monitor=True)
+                monitor.assert_called_once_with(42, timeout=None)
+
+
+class StatusTests(unittest.TestCase):
+    """A set of tests to establish that the ad hoc job status command
+    works in the way that we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_normal(self):
+        """Establish that the data about a ad hoc job retrieved from the jobs
+        endpoint is provided.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            result = self.res.status(42)
+            self.assertEqual(result, {
+                'elapsed': 1335024000.0,
+                'failed': False,
+                'status': 'successful',
+            })
+            self.assertEqual(len(t.requests), 1)
+
+    def test_detailed(self):
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            result = self.res.status(42, detail=True)
+            self.assertEqual(result, {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            self.assertEqual(len(t.requests), 1)
+
+
+class CancelTests(unittest.TestCase):
+    """A set of tasks to establish that the ad hoc job cancel
+    command works in the way that we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_standard_cancelation(self):
+        """Establish that a standard cancelation command works in the way
+        we expect.
+        """
+        with client.test_mode as t:
+            t.register('/ad_hoc_commands/42/cancel/', '', method='POST')
+            result = self.res.cancel(42)
+            self.assertTrue(
+                t.requests[0].url.endswith('/ad_hoc_commands/42/cancel/')
+            )
+            self.assertTrue(result['changed'])
+
+    def test_cancelation_completed_with_error(self):
+        """Establish that a standard cancelation command works in the way
+        we expect.
+        """
+        with client.test_mode as t:
+            t.register('/ad_hoc_commands/42/cancel/', '',
+                       method='POST', status_code=405)
+            with self.assertRaises(exc.TowerCLIError):
+                self.res.cancel(42, fail_if_not_running=True)

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -59,7 +59,7 @@ class GroupTests(unittest.TestCase):
         """Test that anything not covered by the subclass implementation
         simply calls the superclass implementation.
         """
-        with mock.patch.object(models.Resource, 'list') as super_list:
+        with mock.patch.object(models.WritableResource, 'list') as super_list:
             self.gr.list(root=False)
             super_list.assert_called_once_with()
 
@@ -67,7 +67,8 @@ class GroupTests(unittest.TestCase):
         """Establish that if we try to create a group that already exists,
         that we return the standard changed: false.
         """
-        with mock.patch.object(models.Resource, 'create') as super_create:
+        with mock.patch.object(models.WritableResource, 'create') \
+                as super_create:
             super_create.return_value = {'changed': False, 'id': 1}
             with client.test_mode as t:
                 answer = self.gr.create(name='Foo', inventory=1,
@@ -128,7 +129,8 @@ class GroupTests(unittest.TestCase):
         """Establish that if we attempt to modify a group and the group itself
         exists, that we do not attempt to hit the inventory source at all.
         """
-        with mock.patch.object(models.Resource, 'modify') as super_modify:
+        with mock.patch.object(models.WritableResource, 'modify') \
+                as super_modify:
             super_modify.return_value = {'changed': False}
             with client.test_mode as t:
                 self.gr.modify(42, source='rax',

--- a/tests/test_resources_user.py
+++ b/tests/test_resources_user.py
@@ -1,0 +1,66 @@
+# Copyright 2015, Ansible, Inc.
+# Alan Rominger <arominger@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+
+from tests.compat import unittest
+
+
+class CreateTests(unittest.TestCase):
+    """Tests to creation of a user under the relevant circumstances.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('user')
+
+    def test_create_with_organization(self):
+        """Establish that a user can be created within an organization
+        """
+        with client.test_mode as t:
+            endpoint = '/organizations/1/users/'
+            t.register_json(endpoint, {'count': 0, 'results': [],
+                            'next': None, 'previous': None},
+                            method='GET')
+            t.register_json(endpoint, {'changed': True, 'id': 42},
+                            method='POST')
+            # The organization endpoint used to lookup org pk given org name
+            t.register_json('/organizations/1/', {'id': 1}, method='GET')
+            result = self.res.create(
+                username='bill', password="password",
+                organization=1, email="asdf@asdf.com"
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[-1].method, 'POST')
+            self.assertDictContainsSubset({'id': 42}, result)
+
+    def test_create_without_organization(self):
+        """Establish that a user can be created within an organization
+        """
+        with client.test_mode as t:
+            endpoint = '/users/'
+            t.register_json(endpoint, {'count': 0, 'results': [],
+                            'next': None, 'previous': None},
+                            method='GET')
+            t.register_json(endpoint, {'changed': True, 'id': 42},
+                            method='POST')
+            t.register_json('/users/?username=bill',
+                            {'count': 0, 'results': []}, method='GET')
+            result = self.res.create(
+                username='bill', password="password",
+                email="asdf@asdf.com"
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[-1].method, 'POST')
+            self.assertDictContainsSubset({'id': 42}, result)

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added fields to the (hidden) resource inventory_source and options to the resource group. You can use the group create or group modify command to set these options. Those options include:
- source_regions
- source_vars
- overwrite
- overwrite_vars
- update_on_launch
- update_cache_timeout

Even with these added, not all possibilities are covered. For instance, for EC2 specifically we are not covering:
- instance fileters
- only group by

There are even more if you want to dig in the API, but unless someone specifically articulates a need for these, I'm not going to assume that they should be included at this point.

This survives manual testing. Since there is no logic added, there are no unit tests to add.

Note that if you create a group with the CLI and specify the region, it will not show up in the UI. However, if I specify a region in the UI and save it, it doesn't show in that case either. That might be my own server version, or it might be a UI bug.

I first set this PR to compare the ad_hoc branch as a base. That did not work, so I'm changing it to master in the main repo, and we will go from there.