### PR TITLE
ad hoc command added to resolve #61, column edit to resolve #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ $ tower-cli user get --username=guido
 
 # Create a new user.
 $ tower-cli user create --username=guido --first-name=Guido \
-                        --last-name="Van Rossum" --email=guido@python.org
+                        --last-name="Van Rossum" --email=guido@python.org \
+                        --password=password1234
 
 # Modify an existing user.
 # This would modify the first name of the user with the ID of "42" to "Guido".
@@ -213,7 +214,6 @@ $ tower-cli config verify_ssl false
 # Disable insecure connection warnings for just this command
 $ tower-cli job_template list --insecure
 ```
-
 
 ### License
 

--- a/lib/tower_cli/models/__init__.py
+++ b/lib/tower_cli/models/__init__.py
@@ -12,9 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# flake8: noqa
 
-from __future__ import absolute_import, unicode_literals  # NOQA
+from __future__ import absolute_import, unicode_literals
 
-from tower_cli.models.base import BaseResource, Resource, MonitorableResource  # NOQA
-from tower_cli.models.fields import Field  # NOQA
-from tower_cli.utils.types import File  # NOQA
+from tower_cli.models.base import Resource, MonitorableResource, ExeResource, \
+                                  BaseResource
+from tower_cli.models.fields import Field
+from tower_cli.utils.types import File

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -24,6 +24,7 @@ import re
 import sys
 import time
 from copy import copy
+from sdict import adict
 
 import six
 
@@ -320,6 +321,7 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
 
                 # Sanity check: If there is a "changed" key in our payload
                 # and little else, we print a short message and not a table.
+                # this specifically applies to deletion
                 if 'changed' in payload and 'id' not in payload:
                     return 'OK. (changed: {0})'.format(
                         six.text_type(payload['changed']).lower(),
@@ -328,6 +330,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                 # Sanity check: If there is no ID and no results, then this
                 # is unusual output; keep our table formatting, but plow
                 # over the columns-as-keys stuff above.
+                # this originally applied to launch/status/update methods
+                # but it may become deprecated
                 if 'id' not in payload and 'results' not in payload:
                     columns = [i for i in payload.keys()]
 
@@ -404,10 +408,14 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
         return Subcommand(resource=self)
 
 
-class Resource(BaseResource):
+class ResourceMethods(BaseResource):
     """Abstract subclass of BaseResource that adds the standard create,
     modify, list, get, and delete methods.
-    """
+
+    Some of these methods are not created as commands, but will be
+    implemented as commands inside of non-abstract child classes.
+    Particularly, create is not a command in this class, but will be for
+    some (but not all) child classes."""
     abstract = True  # Not inherited.
 
     # The basic methods for interacting with a resource are `read`, `write`,
@@ -417,6 +425,16 @@ class Resource(BaseResource):
     # Most likely, `read` and `write` won't see much direct use; rather,
     # `get` and `list` are wrappers around `read` and `create` and
     # `modify` are wrappers around `write`.
+
+    def _pop_none(self, kwargs):
+        """Remove default values (anything where the value is None).
+        click is unfortunately bad at the way it sends through unspecified
+        defaults."""
+        for key, value in copy(kwargs).items():
+            if value is None:
+                kwargs.pop(key)
+            if hasattr(value, 'read'):
+                kwargs[key] = value.read()
 
     def read(self, pk=None, fail_on_no_results=False,
              fail_on_multiple_results=False, **kwargs):
@@ -444,13 +462,7 @@ class Resource(BaseResource):
         queries = kwargs.pop('query', [])
 
         # Remove default values (anything where the value is None).
-        # click is unfortunately bad at the way it sends through unspecified
-        # defaults.
-        for key, value in copy(kwargs).items():
-            if value is None:
-                kwargs.pop(key)
-            if hasattr(value, 'read'):
-                kwargs[key] = value.read()
+        self._pop_none(kwargs)
 
         # If queries were provided, process them.
         for query in queries:
@@ -513,13 +525,7 @@ class Resource(BaseResource):
         existing_data = {}
 
         # Remove default values (anything where the value is None).
-        # click is unfortunately bad at the way it sends through unspecified
-        # defaults.
-        for key, value in copy(kwargs).items():
-            if value is None:
-                kwargs.pop(key)
-            if hasattr(value, 'read'):
-                kwargs[key] = value.read()
+        self._pop_none(kwargs)
 
         # Determine which record we are writing, if we weren't given a
         # primary key.
@@ -695,7 +701,6 @@ class Resource(BaseResource):
         # Done; return the response
         return response
 
-    @resources.command
     @click.option('--fail-on-found', default=False,
                   show_default=True, type=bool, is_flag=True,
                   help='If used, return an error if a matching record already '
@@ -806,7 +811,7 @@ class Resource(BaseResource):
             return {}
 
 
-class MonitorableResource(Resource):
+class MonitorableResource(ResourceMethods):
     """A resource that is able to be tied to a running task, such as a job
     or project, and thus able to be monitored.
     """
@@ -828,7 +833,7 @@ class MonitorableResource(Resource):
                   help='If provided, this command (not the job) will time out '
                        'after the given number of seconds.')
     def monitor(self, pk, min_interval=1, max_interval=30,
-                timeout=None, outfile=sys.stdout):
+                timeout=None, outfile=sys.stdout, **kwargs):
         """Monitor a running job.
 
         Blocks further input until the job completes (whether successfully or
@@ -847,7 +852,7 @@ class MonitorableResource(Resource):
         # and run in Python.  This seems fine; outfile can be set to /dev/null
         # and very much the normal use for this method should be CLI
         # monitoring.
-        result = self.status(pk)
+        result = self.status(pk, detail=True)
         last_poll = time.time()
         timeout_check = 0
         while result['status'] != 'successful':
@@ -899,7 +904,7 @@ class MonitorableResource(Resource):
             # to the next time that we intend to do a check, and once that
             # time hits, we do the status check as part of the normal cycle.
             if time.time() - last_poll > interval:
-                result = self.status(pk)
+                result = self.status(pk, detail=True)
                 last_poll = time.time()
                 interval = min(interval * 1.5, max_interval)
 
@@ -914,5 +919,99 @@ class MonitorableResource(Resource):
                 secho('\r' + ' ' * longest_string, file=outfile, nl=False)
                 secho('\r', file=outfile, nl=False)
 
-        # Done; return the result
-        return result
+        # Return the job ID and other response data
+        answer = OrderedDict((
+            ('changed', True),
+            ('id', pk),
+        ))
+        answer.update(result)
+        # Make sure to return ID of resource and not update number
+        # relevant for project creation and update
+        answer['id'] = pk
+        return answer
+
+
+class ExeResource(MonitorableResource):
+    """Executable resource - defines status and cancel methods"""
+    abstract = True
+
+    @resources.command
+    @click.option('--detail', is_flag=True, default=False,
+                  help='Print more detail.')
+    def status(self, pk=None, detail=False, **kwargs):
+        """Print the current job status. This is used to check a running job.
+        You can look up the job with the same parameters used for a get
+        request."""
+        # Remove default values (anything where the value is None).
+        self._pop_none(kwargs)
+
+        # Search for the record if pk not given
+        if not pk:
+            job = self.get(include_debug_header=True, **kwargs)
+        # Get the job from Ansible Tower if pk given
+        else:
+            debug.log('Asking for job status.', header='details')
+            finished_endpoint = '%s%d/' % (self.endpoint, pk)
+            job = client.get(finished_endpoint).json()
+
+        # In most cases, we probably only want to know the status of the job
+        # and the amount of time elapsed. However, if we were asked for
+        # verbose information, provide it.
+        if detail:
+            return job
+
+        # Print just the information we need.
+        return adict({
+            'elapsed': job['elapsed'],
+            'failed': job['failed'],
+            'status': job['status'],
+        })
+
+    @resources.command
+    @click.option('--fail-if-not-running', is_flag=True, default=False,
+                  help='Fail loudly if the job is not currently running.')
+    def cancel(self, pk=None, fail_if_not_running=False, **kwargs):
+        """Cancel a currently running job.
+
+        Fails with a non-zero exit status if the job cannot be canceled.
+        You must provide either a pk or parameters in the job's identity.
+        """
+        # Search for the record if pk not given
+        if not pk:
+            existing_data = self.get(**kwargs)
+            pk = existing_data['id']
+
+        cancel_endpoint = '%s%d/cancel/' % (self.endpoint, pk)
+        # Attempt to cancel the job.
+        try:
+            client.post(cancel_endpoint)
+            changed = True
+        except exc.MethodNotAllowed:
+            changed = False
+            if fail_if_not_running:
+                raise exc.TowerCLIError('Job not running.')
+
+        # Return a success.
+        return adict({'status': 'canceled', 'changed': changed})
+
+
+class Resource(ResourceMethods):
+    """This is the parent class for all 'standard' resources."""
+    abstract = True
+
+    @resources.command
+    @click.option('--fail-on-found', default=False,
+                  show_default=True, type=bool, is_flag=True,
+                  help='If used, return an error if a matching record already '
+                       'exists.')
+    @click.option('--force-on-exists', default=False,
+                  show_default=True, type=bool, is_flag=True,
+                  help='If used, if a match is found on unique fields, other '
+                       'fields will be updated to the provided values. If '
+                       'False, a match causes the request to be a no-op.')
+    def create(self, fail_on_found=False, force_on_exists=False, **kwargs):
+        """Create an object by implementing the super class version of create.
+        """
+        return super(Resource, self).create(
+            fail_on_found=False, force_on_exists=False, **kwargs
+        )

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -701,41 +701,17 @@ class ResourceMethods(BaseResource):
         # Done; return the response
         return response
 
-    @click.option('--fail-on-found', default=False,
-                  show_default=True, type=bool, is_flag=True,
-                  help='If used, return an error if a matching record already '
-                       'exists.')
-    @click.option('--force-on-exists', default=False,
-                  show_default=True, type=bool, is_flag=True,
-                  help='If used, if a match is found on unique fields, other '
-                       'fields will be updated to the provided values. If '
-                       'False, a match causes the request to be a no-op.')
     def create(self, fail_on_found=False, force_on_exists=False, **kwargs):
-        """Create an object.
-
-        Fields in the resource's `identity` tuple are used for a lookup;
-        if a match is found, then no-op (unless `force_on_exists` is set) but
-        do not fail (unless `fail_on_found` is set).
-        """
+        """The code for the create method in a non-command implementation
+        here, so that the child classes can over-ride it as a command,
+        depending on circumstances."""
         return self.write(create_on_missing=True, fail_on_found=fail_on_found,
                           force_on_exists=force_on_exists, **kwargs)
 
-    @resources.command
-    @click.option('--create-on-missing', default=False,
-                  show_default=True, type=bool, is_flag=True,
-                  help='If used, and if options rather than a primary key are '
-                       'used to attempt to match a record, will create the '
-                       'record if it does not exist. This is an alias to '
-                       '`create --force-on-exists`.')
     def modify(self, pk=None, create_on_missing=False, **kwargs):
-        """Modify an already existing object.
-
-        Fields in the resource's `identity` tuple can be used in lieu of a
-        primary key for a lookup; in such a case, only other fields are
-        written.
-
-        To modify unique fields, you must use the primary key for the lookup.
-        """
+        """The code for the modify method in a non-command implementation
+        here, so that the child classes can over-ride it as a command,
+        depending on circumstances."""
         force_on_exists = kwargs.pop('force_on_exists', True)
         return self.write(pk, create_on_missing=create_on_missing,
                           force_on_exists=force_on_exists, **kwargs)
@@ -996,7 +972,7 @@ class ExeResource(MonitorableResource):
 
 
 class Resource(ResourceMethods):
-    """This is the parent class for all 'standard' resources."""
+    """This is the parent class for all standard resources."""
     abstract = True
 
     @resources.command
@@ -1010,8 +986,32 @@ class Resource(ResourceMethods):
                        'fields will be updated to the provided values. If '
                        'False, a match causes the request to be a no-op.')
     def create(self, fail_on_found=False, force_on_exists=False, **kwargs):
-        """Create an object by implementing the super class version of create.
+        """Create an object.
+
+        Fields in the resource's `identity` tuple are used for a lookup;
+        if a match is found, then no-op (unless `force_on_exists` is set) but
+        do not fail (unless `fail_on_found` is set).
         """
         return super(Resource, self).create(
             fail_on_found=False, force_on_exists=False, **kwargs
         )
+
+    @resources.command
+    @click.option('--create-on-missing', default=False,
+                  show_default=True, type=bool, is_flag=True,
+                  help='If used, and if options rather than a primary key are '
+                       'used to attempt to match a record, will create the '
+                       'record if it does not exist. This is an alias to '
+                       '`create --force-on-exists`.')
+    def modify(self, pk=None, create_on_missing=False, **kwargs):
+        """Modify an already existing object.
+
+        Fields in the resource's `identity` tuple can be used in lieu of a
+        primary key for a lookup; in such a case, only other fields are
+        written.
+
+        To modify unique fields, you must use the primary key for the lookup.
+        """
+        force_on_exists = kwargs.pop('force_on_exists', True)
+        return self.write(pk, create_on_missing=create_on_missing,
+                          force_on_exists=force_on_exists, **kwargs)

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -1,0 +1,122 @@
+# Copyright 2015, Ansible, Inc.
+# Alan Rominger <arominger@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, unicode_literals
+
+import click
+
+from tower_cli import models, resources
+from tower_cli.api import client
+from tower_cli.utils import debug, exceptions as exc, types
+from tower_cli.utils.data_structures import OrderedDict
+
+
+class Resource(models.ExeResource):
+    """A resource for ad hoc commands."""
+    cli_help = 'Launch commands based on playbook given at runtime.'
+    endpoint = '/ad_hoc_commands/'
+
+    # Parameters similar to job
+    job_explanation = models.Field(required=False, display=False)
+    created = models.Field(required=False, display=True)
+    status = models.Field(required=False, display=True)
+    elapsed = models.Field(required=False, display=True)
+
+    # Parameters similar to job_template
+    job_type = models.Field(
+        default='run',
+        display=False,
+        show_default=True,
+        type=click.Choice(['run', 'check']),
+    )
+    inventory = models.Field(type=types.Related('inventory'))
+    machine_credential = models.Field(
+        'credential',
+        display=False,
+        type=types.Related('credential'),
+    )
+    cloud_credential = models.Field(type=types.Related('credential'),
+                                    required=False, display=False)
+    module_name = models.Field(required=False, display=True,
+                               default="command", show_default=True)
+    module_args = models.Field(required=False, display=False)
+    forks = models.Field(type=int, required=False, display=False)
+    limit = models.Field(required=False, display=False)
+    verbosity = models.Field(
+        display=False,
+        type=types.MappedChoice([
+            (0, 'default'),
+            (1, 'verbose'),
+            (2, 'debug'),
+        ]),
+        required=False,
+    )
+
+    @resources.command(
+        use_fields_as_options=(
+            'job_explanation', 'job_type', 'inventory', 'machine_credential',
+            'cloud_credential', 'module_name', 'module_args', 'forks',
+            'limit', 'verbosity', 'become_enabled',
+        )
+    )
+    @click.option('--monitor', is_flag=True, default=False,
+                  help='If sent, immediately calls `monitor` on the newly '
+                       'launched command rather than exiting with a success.')
+    @click.option('--timeout', required=False, type=int,
+                  help='If provided with --monitor, this attempt'
+                       ' will time out after the given number of seconds. '
+                       'Does nothing if --monitor is not sent.')
+    @click.option('--become', required=False, is_flag=True,
+                  help='If used, privledge escalation will be enabled for '
+                       'this command.')
+    def launch(self, monitor=False, timeout=None, become=False, **kwargs):
+        """Launch a new ad-hoc command.
+
+        Runs a user-defined command from Ansible Tower, immediately starts it,
+        and returns back an ID in order for its status to be monitored.
+        """
+        # This feature only exists for versions 2.2 and up
+        r = client.get('/')
+        if 'ad_hoc_commands' not in r.json():
+            raise exc.TowerCLIError('Your host is running an outdated version'
+                                    'of Ansible Tower that can not run '
+                                    'ad-hoc commands (2.2 or earlier)')
+
+        # Pop the None arguments because we have no .write() method in
+        # inheritance chain for this type of resource. This is needed
+        self._pop_none(kwargs)
+
+        # Change the flag to the dictionary format
+        if become:
+            kwargs['become_enabled'] = True
+
+        # Actually start the command.
+        debug.log('Launching the ad-hoc command.', header='details')
+        result = client.post(self.endpoint, data=kwargs)
+        command = result.json()
+        command_id = command['id']
+
+        # If we were told to monitor the command once it started, then call
+        # monitor from here.
+        if monitor:
+            return self.monitor(command_id, timeout=timeout)
+
+        # Return the command ID and other response data
+        answer = OrderedDict((
+            ('changed', True),
+            ('id', command_id),
+        ))
+        answer.update(result.json())
+        return answer

--- a/lib/tower_cli/resources/credential.py
+++ b/lib/tower_cli/resources/credential.py
@@ -34,13 +34,14 @@ class Resource(models.Resource):
         required=False,
     )
     team = models.Field(
-        display=False,
+        display=True,
         type=types.Related('team'),
         required=False,
     )
 
     # What type of credential is this (machine, SCM, etc.)?
     kind = models.Field(
+        display=True,
         help_text='The type of credential being added. '
                   'Valid options are: ssh, scm, aws, rax, vmware,'
                   ' gce, azure, openstack.',
@@ -51,12 +52,12 @@ class Resource(models.Resource):
     # need host in order to use VMware
     host = models.Field(
         help_text='The hostname or IP address to use.',
-        required=False,
+        required=False, display=False
     )
     # need project to use openstack
     project = models.Field(
         help_text='The identifier for the project.',
-        required=False
+        required=False, display=False
     )
 
     # SSH and SCM fields.

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -58,8 +58,7 @@ class Resource(models.Resource):
     job_tags = models.Field(required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(required=False, display=False)
-    become_enabled = models.Field(type=bool, required=False, display=False,
-                                  show_default=True, default=False)
+    become_enabled = models.Field(type=bool, required=False, display=False)
 
     @resources.command
     @click.option('--extra-vars', required=False, multiple=True,
@@ -76,7 +75,7 @@ class Resource(models.Resource):
         return super(Resource, self).create(*args, **kwargs)
 
     @resources.command
-    def modify(self, *args, **kwargs):
+    def modify(self, pk=None, *args, **kwargs):
         """Modify a job template.
         You may only include one --extra-vars flag with this command, and
         whatever you provde will overwrite the existing field. Start this
@@ -85,4 +84,4 @@ class Resource(models.Resource):
             # read from file, if given
             kwargs['extra_vars'] = \
                 parser.file_or_yaml_split(kwargs['extra_vars'])
-        return super(Resource, self).modify(*args, **kwargs)
+        return super(Resource, self).modify(pk=pk, *args, **kwargs)

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -17,7 +17,7 @@ import click
 
 from sdict import adict
 
-from tower_cli import models, resources
+from tower_cli import models, get_resource, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
 
@@ -53,27 +53,48 @@ class Resource(models.MonitorableResource):
     scm_update_on_launch = models.Field(type=bool, required=False,
                                         display=False)
 
+    @click.option('--monitor', is_flag=True, default=False,
+                  help='If sent, immediately calls `project monitor` on the '
+                       'project rather than exiting with a success.'
+                       'It polls for status until the SCM is updated.')
+    @click.option('--timeout', required=False, type=int,
+                  help='If provided with --monitor, the SCM update'
+                       ' will time out after the given number of seconds. '
+                       'Does nothing if --monitor is not sent.')
     @resources.command
-    def create(self, *args, **kwargs):
-        """Create a project, with or w/o org.
-        Fix for issue #52, second method, replacing the /projects/
-        endpoint temporarily if the project has an organization specified
+    def create(self, organization=None, monitor=False, timeout=None,
+               *args, **kwargs):
+        """Create a new item of resource, with or w/o org.
+        This would be a shared class with user, but it needs the ability
+        to monitor if the flag is set.
         """
-        if "organization" in kwargs:
-            debug.log("using alternative endpoint for new project",
+        backup_endpoint = self.endpoint
+        if organization:
+            debug.log("using alternative endpoint specific to organization",
                       header='details')
-            org_pk = kwargs['organization']
-            self.endpoint = '/organizations/%s/projects/' % org_pk
-        to_return = super(Resource, self).create(*args, **kwargs)
-        self.endpoint = '/projects/'
-        return to_return
+
+            # Get the organization from Tower, will lookup name if needed
+            org_resource = get_resource('organization')
+            org_data = org_resource.get(organization)
+            org_pk = org_data['id']
+
+            self.endpoint = '/organizations/%s%s' % (org_pk, backup_endpoint)
+        answer = super(Resource, self).create(*args, **kwargs)
+        self.endpoint = backup_endpoint
+
+        # if the monitor flag is set, wait for the SCM to update
+        if monitor:
+            project_id = answer['id']
+            return self.monitor(project_id, timeout=timeout)
+
+        return answer
 
     @resources.command(use_fields_as_options=(
         'name', 'description', 'scm_type', 'scm_url', 'local_path',
         'scm_branch', 'scm_credential', 'scm_clean', 'scm_delete_on_update',
         'scm_update_on_launch'
     ))
-    def modify(self, *args, **kwargs):
+    def modify(self, pk=None, *args, **kwargs):
         """Modify a project, see org help to modify org.
         Also associated with issue #52, the organization can't be modified
         with the 'modify' command. This would create confusion about whether
@@ -81,7 +102,7 @@ class Resource(models.MonitorableResource):
         method is used to set the allowed fields on the modify command,
         removing the organization from available options.
         """
-        return super(Resource, self).modify(*args, **kwargs)
+        return super(Resource, self).modify(pk=pk, *args, **kwargs)
 
     @resources.command(use_fields_as_options=('name', 'organization'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -95,13 +95,22 @@ class Resource(models.MonitorableResource):
         'scm_update_on_launch'
     ))
     def modify(self, pk=None, *args, **kwargs):
-        """Modify a project, see org help to modify org.
-        Also associated with issue #52, the organization can't be modified
-        with the 'modify' command. This would create confusion about whether
-        it served the role of an identifier versus a field to modify. This
-        method is used to set the allowed fields on the modify command,
-        removing the organization from available options.
+        """Modify an already existing.
+
+        To edit the project's organizations, see help for organizations.
+
+        Fields in the resource's `identity` tuple can be used in lieu of a
+        primary key for a lookup; in such a case, only other fields are
+        written.
+
+        To modify unique fields, you must use the primary key for the lookup.
         """
+        # Associated with issue #52, the organization can't be modified
+        #    with the 'modify' command. This would create confusion about
+        #    whether its flag is an identifier versus a field to modify.
+        # Another role this method serves is to re-implement the modify
+        #    method as a command. If this method is deleted, the inheritance
+        #    chain for project should also be changed.
         return super(Resource, self).modify(pk=pk, *args, **kwargs)
 
     @resources.command(use_fields_as_options=('name', 'organization'))

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -1,0 +1,204 @@
+# Copyright 2015, Ansible, Inc.
+# Alan Rominger <arominger@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+from tower_cli.utils import exceptions as exc
+
+from tests.compat import unittest, mock
+from tower_cli.conf import settings
+import json
+
+import click
+
+
+class LaunchTests(unittest.TestCase):
+    """A set of tests for ensuring that the ad hoc resource's
+    launch command works in the way we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_basic_launch(self):
+        """Establish that we are able to run an ad hoc command.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            result = self.res.launch(inventory="foobar", machine_credential=2)
+            self.assertEqual(result, {'changed': True, 'id': 42})
+
+    def test_launch_with_become(self):
+        """Establish that we are able use the --become flag
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            self.res.launch(inventory="foobar", machine_credential=2,
+                            become=True)
+            # Critically, we test that the request sent to the server
+            # contains the key "become_enabled", as this must be triggered
+            # by the conditional written specifically for --become
+            self.assertDictContainsSubset(
+                {'become_enabled': True},
+                json.loads(t.requests[1].body)
+            )
+
+    def test_basic_launch_with_echo(self):
+        """Establish that we are able to run an ad hoc command and also
+        print that to the command line without errors.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
+            t.register_json(
+                '/ad_hoc_commands/',
+                {'changed': True, 'id': 42,
+                    'inventory': 'foobar', 'credential': 2,
+                    'name': 'ping', 'created': 1234, 'elapsed': 2352,
+                    'status': 'successful', 'module_name': 'command',
+                    'limit': '', }, method='POST'
+            )
+            result = self.res.launch(inventory="foobar", machine_credential=2)
+            self.assertEqual(result['changed'], True)
+            self.assertEqual(result['id'], 42)
+
+            f = self.res.as_command()._echo_method(self.res.launch)
+            with mock.patch.object(click, 'secho'):
+                with settings.runtime_values(format='human'):
+                    f(inventory="foobar", machine_credential=2)
+
+    def test_launch_with_param(self):
+        """Establish that we are able to run an ad hoc command.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            result = self.res.launch(inventory="foobar", machine_credential=2,
+                                     module_args="echo 'hi'")
+            self.assertEqual(result, {'changed': True, 'id': 42})
+
+    def test_version_failure(self):
+        """Establish that if the command has failed, that we raise the
+        JobFailure exception.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {}, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+            with self.assertRaises(exc.TowerCLIError):
+                self.res.launch(inventory=1, machine_credential=2,
+                                module_args="echo 'hi'")
+
+    def test_basic_launch_monitor_option(self):
+        """Establish that we are able to run a command and monitor
+        it, if requested.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
+            t.register_json('/', {
+                'ad_hoc_commands': '/api/v1/ad_hoc_commands/'
+                }, method='GET')
+            t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
+
+            with mock.patch.object(type(self.res), 'monitor') as monitor:
+                self.res.launch(inventory=1, machine_credential=2,
+                                module_args="echo 'hi'", monitor=True)
+                monitor.assert_called_once_with(42, timeout=None)
+
+
+class StatusTests(unittest.TestCase):
+    """A set of tests to establish that the ad hoc job status command
+    works in the way that we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_normal(self):
+        """Establish that the data about an ad hoc command retrieved
+        from the jobs endpoint is provided.
+        """
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            result = self.res.status(42)
+            self.assertEqual(result, {
+                'elapsed': 1335024000.0,
+                'failed': False,
+                'status': 'successful',
+            })
+            self.assertEqual(len(t.requests), 1)
+
+    def test_detailed(self):
+        with client.test_mode as t:
+            t.register_json('/ad_hoc_commands/42/', {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            result = self.res.status(42, detail=True)
+            self.assertEqual(result, {
+                'elapsed': 1335024000.0,
+                'extra': 'ignored',
+                'failed': False,
+                'status': 'successful',
+            })
+            self.assertEqual(len(t.requests), 1)
+
+
+class CancelTests(unittest.TestCase):
+    """A set of tasks to establish that the ad hoc cancel
+    command works in the way that we expect.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('ad_hoc')
+
+    def test_standard_cancelation(self):
+        """Establish that a standard cancelation command works in the way
+        we expect.
+        """
+        with client.test_mode as t:
+            t.register('/ad_hoc_commands/42/cancel/', '', method='POST')
+            result = self.res.cancel(42)
+            self.assertTrue(
+                t.requests[0].url.endswith('/ad_hoc_commands/42/cancel/')
+            )
+            self.assertTrue(result['changed'])
+
+    def test_cancelation_completed_with_error(self):
+        """Establish that a standard cancelation command works in the way
+        we expect.
+        """
+        with client.test_mode as t:
+            t.register('/ad_hoc_commands/42/cancel/', '',
+                       method='POST', status_code=405)
+            with self.assertRaises(exc.TowerCLIError):
+                self.res.cancel(42, fail_if_not_running=True)

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -1,5 +1,5 @@
 # Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Alan Rominger <arominger@ansible.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ad hoc command added and some changes were correspondingly made to job, as these are both implemented through the ExeResource class (an extension of MonitorableResource), covering status and cancel. The previous class Resource in base.py was renamed ResouceMethods but retains the existing ordering of methods in the master branch, and this was changed from the last version of this PR. The "create" method is converted into a command inside of the Resource class in base.py so that the majority of resources can continue to inherit from it in the same way as before, but still leaving off the method from the command-line options for the cases of job and ad hoc resources.

Several changes were also made in order to print a free-form list of columns when running, monitoring, or checking the status of an ad hoc command, but these changes also apply to running a job. These methods were excluded from the special case in the _format_human method that checked if a unique combination of keys existed in the returned dictionary, and narrowed the list of columns if that were the case. Almost every other resource+command combination (which one set of exceptions, I can elaborate on later) has the fields flagged with display=True printed. Since ad hoc commands borrow fields (which are typically displayed in this way) from job template, it was written to follow this format, even though doing so demanded making some changes to the way status, cancel, and monitor operate. That is what is typically going on when you see **kwargs addition in the code, and I have attempted to be as meticulous as possible checking to see that these alterations don't negatively affect anything else.

Additionally, some errors with lookups were changed in a way that affected more resources than just ad hoc. For an example of what I'm talking about, I would like to be able to call `job launch --job-template=hello_world` as well as `job launch --job-template=7`, if that specific job template has a pk of 7. Switching logic for integers versus names should be pretty automatic, and it typically is, but some cases where the modify method is over-ridden (for instance), and when multiple contributors made changes to these implementations, support for one or the other has been unintentionally dropped. Some edits here deal with that, either with the pk specifier, or a custom set of logic that has already been used in a number of resources here and there. A more thorough audit of this behavior is left for the future.

One problem with test coverage did come up for this PR in particular. There is a statement that replaces all occurrences of underscores with hyphens in the help_text. I don't actually see where underscores were ever used in the help text, so this explains why it was not covered. It's harder to explain why it was covered in the past, but I will look into it.