### PR TITLE
Additional inventory source options added

### DIFF
--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -50,7 +50,7 @@ class Resource(models.Resource):
     @click.option('--overwrite-vars', type=bool,
                   help='Override vars in child groups and hosts with those '
                   'from the external source.')
-    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+    @click.option('--update-on-launch', type=bool, help='Refresh inventory '
                   'data from its source each time a job is run.')
     def create(self, credential=None, source=None, **kwargs):
         """Create a group and, if necessary, modify the inventory source within

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -34,12 +34,24 @@ class Resource(models.Resource):
     variables = models.Field(type=types.File('r'), required=False,
                              display=False)
 
+    # Basic options for the source
     @click.option('--credential', type=types.Related('credential'),
                   required=False,
                   help='The cloud credential to use.')
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def create(self, credential=None, source=None, **kwargs):
         """Create a group and, if necessary, modify the inventory source within
         the group.
@@ -75,6 +87,17 @@ class Resource(models.Resource):
     @click.option('--source', type=click.Choice(INVENTORY_SOURCES),
                   default='manual',
                   help='The source to use for this group.')
+    @click.option('--source-regions', help='Regions for your cloud provider.')
+    # Options may not be valid for certain types of cloud servers
+    @click.option('--source-vars', help='Override variables found on source '
+                  'with variables defined in this field.')
+    @click.option('--overwrite', type=bool,
+                  help='Delete child groups and hosts not found in source.')
+    @click.option('--overwrite-vars', type=bool,
+                  help='Override vars in child groups and hosts with those '
+                  'from the external source.')
+    @click.option('--update-on-launch', type=bool, help='Refersh inventory '
+                  'data from its source each time a job is run.')
     def modify(self, pk=None, credential=None, source=None, **kwargs):
         """Modify a group and, if necessary, the inventory source within
         the group.

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -34,6 +34,16 @@ class Resource(models.MonitorableResource):
         type=click.Choice(['manual', 'ec2', 'rax', 'vmware',
                            'gce', 'azure', 'openstack']),
     )
+    source_regions = models.Field(required=False, display=False)
+    # Variables not shared by all cloud providers
+    source_vars = models.Field(required=False, display=False)
+    # Boolean variables
+    overwrite = models.Field(type=bool, required=False, display=False)
+    overwrite_vars = models.Field(type=bool, required=False, display=False)
+    update_on_launch = models.Field(type=bool, required=False, display=False)
+    # Only used if update_on_launch is used
+    update_cache_timeout = models.Field(type=int, required=False,
+                                        display=False)
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))
     @click.option('--monitor', is_flag=True, default=False,


### PR DESCRIPTION
Additional fields have been added to the "group create" and "group modify" commands. These are passed into the hidden resource inventory_source and from there the API is updated. This solution has been tested manually and there is an example in the script example in another branch.

Additional options include
- source_regions
- source_vars
- overwrite
- overwrite_vars
- update_on_launch
- update_cache_timeout

Even with these added, not all possibilities are covered. For instance, for EC2 specifically we are not covering:

- instance fileters
- only group by

Since there is no logic added, there are no unit tests to add.

There were 2 failed PR filed for this issue, but they had problems with the source it branched off of, and this version should work for the new release.