### PR TITLE
Veryify_ssl config var changed from a warning message flip to an error flip

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,24 @@
+## Release History
+
+## 2.0.0 (2014-07-10)
+
+* Pluggable resource architecture built around click
+
+## 2.0.1 (2014-07-18)
+
+## 2.0.2 (2014-10-02)
+
+### 2.1.0 (2015-01-21)
+
+### 2.3.0 (2015-10-xx)
+
+* Fixed an issue with the settings file so that it could be world readable
+* Added the ability to associate a project with an organization
+* Added setting "verrify_ssl" to disallow insecure connections
+* Added support for additional cloud credentials
+* Exposed additional options for a cloud inventory source
+* Combined " launch-time extra_vars" with " job_template extra_vars" for older Tower versions
+* Changed the extra_vars parameters to align with Ansible parameter handling
+* Added the ability to run ad hoc commands
+* Included more detail when displaying job information
+* Added an example bash script to demonstrate tower-cli usage

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 
 ### 2.3.0 (2015-10-xx)
 
-* Fixed an issue with the settings file so that it could be world readable
+* Fixed an issue where the settings file could be world readable
 * Added the ability to associate a project with an organization
 * Added setting "verrify_ssl" to disallow insecure connections
 * Added support for additional cloud credentials

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ as its value.
 
 By default tower-cli will raise an error if the SSL certificate of the Tower server
 cannot be verified. To allow unverified SSL connections, set the config
-variable `verify_ssl` to true. To allow it just for a single command, add the
+variable `verify_ssl` to true. To allow it for a single command, add the
 --insecure flag.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ as its value.
 
 #### SSL warnings
 
-By default tower-cli warns if the SSL certificate of the Tower server
-cannot be verified. To disable this warning, set the config variable
-`verify_ssl` to true. To disable it for a single command, add the
+By default tower-cli will raise an error if the SSL certificate of the Tower server
+cannot be verified. To allow unverified SSL connections, set the config
+variable `verify_ssl` to true. To allow it just for a single command, add the
 --insecure flag.
 
 ```bash

--- a/docs/examples/teardown_script.sh
+++ b/docs/examples/teardown_script.sh
@@ -2,6 +2,9 @@
 # runs and ad hoc commands because there is no "name" identifier that
 # we can use to automatically look them up.
 
+echo "Tower-CLI DATA FAKER: displaying jobs that must be deleted manually using ID"
+tower-cli job list --job-template=hello_world
+
 echo "Tower-CLI DATA FAKER: deleting job templates"
 tower-cli job_template delete --name="hello_world"
 tower-cli job_template delete --name="ls_1_to_2"
@@ -51,6 +54,3 @@ tower-cli team delete --name Engineering
 tower-cli team delete --name "Tech Services"
 tower-cli organization delete --name="Hyrule Ventures"
 tower-cli organization delete --name="Bio Inc"
-
-echo "Tower-CLI DATA FAKER: displaying jobs that must be deleted manually using ID"
-tower-cli job list --job-template=hello_world

--- a/lib/tower_cli/api.py
+++ b/lib/tower_cli/api.py
@@ -18,7 +18,6 @@ import copy
 import functools
 import json
 import warnings
-import click
 
 from requests.exceptions import ConnectionError, SSLError
 from requests.sessions import Session

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,5 +175,5 @@ class ClientTests(unittest.TestCase):
                     g.assert_called_once_with(
                         # The pont is to assure verify=False below
                         'GET', mock.ANY, allow_redirects=True,
-                        auth=('admin', 'password'), verify=False
+                        auth=(mock.ANY, mock.ANY), verify=False
                     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,7 +160,7 @@ class ClientTests(unittest.TestCase):
             with self.assertRaises(exc.BadRequest):
                 client.get('/ping/')
 
-    def test_insecure_connecction(self):
+    def test_insecure_connection(self):
         """Establish that the --insecure flag will cause the program to
         call request with verify=False.
         """

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -88,7 +88,7 @@ class ParserTests(unittest.TestCase):
                                                parser.readfp)
                     read_file_method(StringIO('[general]\nfoo: bar\n'))
                     warn.assert_called_once_with(mock.ANY, RuntimeWarning)
-        # Also run with acceptable permissions, verrify that no warning issued
+        # Also run with acceptable permissions, verify that no warning issued
         with mock.patch.object(warnings, 'warn') as warn:
             with mock.patch.object(os.path, 'isfile') as isfile:
                 with mock.patch.object(os, 'stat') as os_stat:

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -89,7 +89,7 @@ class ParserTests(unittest.TestCase):
     def test_handling_bad_data(self):
         """Check robustness of the parser functions in how it handles
         empty strings, null values, etc."""
-        # Verrify that all parts of the computational chain can handle None
+        # Verify that all parts of the computational chain can handle None
         return_dict = parser.parse_kv(None)
         self.assertEqual(return_dict, {})
         return_dict = parser.string_to_dict(None)


### PR DESCRIPTION
Assume we are dealing with a server of Tower that does not have a SSL certificate found in any of the computers certificate authorities.

- Past behavior: if verify_ssl was true, you would get the standard insecure request warning message
- New behavior: if verrify_ssl is true, the connection will be rejected and you will receive an error

The new error message for this scenario is the following.

> Error: Could not establish a secure connection. Please add the server to your certificate authority.
> You can run this command without verifying SSL with the --insecure flag, or permanently disable verification by the config setting:
> 
>  tower-cli config verify_ssl false

If the host is not available, you should still see the same message as always. Care was taken to not conflate those scenarios.

Also, the release notes for the coming 2.3.0 were added in the HISTORY.md file, top level directory.