### PR TITLE
Remove egg_base variable (for Windows compatibility) and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ results.xml
 
 # ignore personal configs
 .tower_cli.cfg
+
+# ignore python egg
+*.egg-info/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[egg_info]
-egg_base = /tmp
-
-
 [nosetests]
 # don't wrap stdout/stderr
 nocapture=1


### PR DESCRIPTION
In response to pull request #34, we are removing the egg_base variable from setup.cfg, which avoids using an OS-specific directory. Also add this type of file to .gitignore to avoid committing unnecessary files later.