### PR TITLE
Convert "_" to "-" in tower-cli missing field error message

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -467,7 +467,8 @@ class ResourceMethods(BaseResource):
         # If queries were provided, process them.
         for query in queries:
             if query[0] in kwargs:
-                raise exc.BadRequest('Attempted to set %s twice.' % query[0])
+                raise exc.BadRequest('Attempted to set %s twice.'
+                                     % query[0].replace('_', '-'))
             kwargs[query[0]] = query[1]
 
         # Make the request to the Ansible Tower API.
@@ -552,7 +553,7 @@ class ResourceMethods(BaseResource):
         missing_fields = [i for i in required_fields if i not in kwargs]
         if missing_fields and not pk:
             raise exc.BadRequest('Missing required fields: %s' %
-                                 ', '.join(missing_fields))
+                                 ', '.join(missing_fields).replace('_', '-'))
 
         # Sanity check: Do we need to do a write at all?
         # If `force_on_exists` is False and the record was, in fact, found,


### PR DESCRIPTION
Issue #56 brought up a confusing behavior displayed by tower-cli, where sometimes its language would use underscores in variables names, and other times it would use dashes instead.

We hold to our previous design decision to use dashes, being consistent with Ansible core and general good practice for command-line based programs. However, there are some small things we can do to clean up error messages that confusingly display underscores. There is no changing the fact that underscores and used in the API, but the user of tower-cli should not have to think about this, or be exposed to variables with underscores in them. For this one particular scenario, I suggest that we just show the user the variable name with dashes.

This fixes the error message when you don't give a required field - as defined by tower-cli. However, there are many special case scenarios where a field is only required if another field is given a certain value. In those cases, the user will be shown an error response from the Tower server, and those will contain underscores. Patching up these responses would be more complicated because you would have to parse it as JSON first. I will leave that work for the future.