### PR TITLE
Fix force-on-exists and fail-if-found errors

### DIFF
--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, unicode_literals
 
 import click
 
-from tower_cli import models, resources
+from tower_cli import models
 from tower_cli.utils import types
 from tower_cli.utils import parser
 
@@ -60,11 +60,11 @@ class Resource(models.Resource):
     extra_vars = models.Field(required=False, display=False)
     become_enabled = models.Field(type=bool, required=False, display=False)
 
-    @resources.command
     @click.option('--extra-vars', required=False, multiple=True,
                   help='yaml format text that contains extra variables '
                        'to pass on. Use @ to get these from a file.')
-    def create(self, extra_vars=None, *args, **kwargs):
+    def create(self, fail_on_found=False, force_on_exists=False,
+               extra_vars=None, **kwargs):
         """Create a job template.
         You may include multiple --extra-vars flags in order to combine
         different sources of extra variables. Start this
@@ -72,10 +72,12 @@ class Resource(models.Resource):
         if extra_vars:
             # combine sources of extra variables, if given
             kwargs['extra_vars'] = parser.extra_vars_loader_wrapper(extra_vars)
-        return super(Resource, self).create(*args, **kwargs)
+        return super(Resource, self).create(
+            fail_on_found=fail_on_found, force_on_exists=force_on_exists,
+            **kwargs
+        )
 
-    @resources.command
-    def modify(self, pk=None, *args, **kwargs):
+    def modify(self, pk=None, create_on_missing=False, **kwargs):
         """Modify a job template.
         You may only include one --extra-vars flag with this command, and
         whatever you provde will overwrite the existing field. Start this
@@ -84,4 +86,6 @@ class Resource(models.Resource):
             # read from file, if given
             kwargs['extra_vars'] = \
                 parser.file_or_yaml_split(kwargs['extra_vars'])
-        return super(Resource, self).modify(pk=pk, *args, **kwargs)
+        return super(Resource, self).modify(
+            pk=pk, create_on_missing=create_on_missing, **kwargs
+        )


### PR DESCRIPTION
This fixes issue #88, which noted that the --force-on-exists option went missing for creation of a project. That is fixed by adding another class to the list of what `project` inherits from. The bug was caused by my removal of the `create` option from the `MonitorableResource` class (in order to omit it from jobs or ad hoc commands). However, this also removed it from `project` (also monitorable), which led to the subtle error of dropping options defined in the parent class of `create`.

`job_template` had the reverse error due to the same nature of misunderstanding. The options were added to the `create` method in `job_template`, even though it inherited from the standard `Resource` class. This caused the help text to display 2 versions for force-on-exists and fail-on-found. Removing the redundant options was the obvious fix, and that is included in this Pull Request.

Some other changes were made that go along this same vein of consistency with the parent classes. Particularly, the argument lists were edited to follow the same standard as the parent class. These were tested and work fine. Only one method was not an error associated with the 2.3.0 release, and that was the project status method, which was non-functioning if invoked from the command line. Conforming its arguments to the other versions of `status` was done to make it usable, and there are no conflicts with its use in `monitor` to my knowledge.