### PR TITLE
Bug fix for 2.3.1 release.

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -994,7 +994,8 @@ class Resource(ResourceMethods):
         do not fail (unless `fail_on_found` is set).
         """
         return super(Resource, self).create(
-            fail_on_found=False, force_on_exists=False, **kwargs
+            fail_on_found=fail_on_found, force_on_exists=force_on_exists,
+            **kwargs
         )
 
     @resources.command

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -30,16 +30,21 @@ class CreateTests(unittest.TestCase):
     def test_create_with_organization(self):
         """Establish that a project can be created inside of an organization.
         This uses the --organization flag with the create command.
-        This action uses the /organizations/{id}/projects/ endpoint
         """
         with client.test_mode as t:
-            endpoint = '/organizations/1/projects/'
-            t.register_json(endpoint, {'count': 0, 'results': [],
+            t.register_json('/projects/', {'count': 0, 'results': [],
                             'next': None, 'previous': None},
                             method='GET')
-            t.register_json(endpoint, {'id': 42}, method='POST')
+            t.register_json('/projects/', {'id': 42}, method='POST')
             # The org endpoint can be used to lookup org pk given org name
             t.register_json('/organizations/1/', {'id': 1}, method='GET')
+            # This is an endpoint used for project-org association
+            t.register_json(
+                '/organizations/1/projects/', {'count': 0}, method='GET'
+            )
+            t.register_json(
+                '/organizations/1/projects/', {'changed': True}, method='POST'
+            )
             result = self.res.create(
                 name='bar', organization=1, scm_type="git"
             )


### PR DESCRIPTION
This is a followup to issue #88. My apologies for merging before the testing was airtight. Both `--force-on-exists` and `--fail-on-found` were still broken for all uses of "create" due to a careless error.

There was a more complicated issue where `--force-on-exists` switches to PATCH instead of POST when an existing project is found. This results in an attempt to PATCH `/organizations/{org pk}/projects/{project pk}/`, which is an invalid endpoint. To fix this, the process for creation of a project belonging to an organization was changed so that a POST is made to `/projects/` and then the `_assoc` method is called right after that. This makes it consistent with the rest of the code base, and provides a resolution to this bug.

With this pull request I am updating the version number to prepare for release because these are fairly important fixes. Let me know if there is anything else I should do differently for the release process.