### PR TITLE
Inventory Script subcommand added

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+2.4.0 (2015-12-xx)
+------------------
+- Added inventory script sub-command
+
 2.3.1 (2015-12-10)
 ------------------
 
@@ -8,6 +12,7 @@ Release History
 - Changed extra_vars behavior to be more compliant by re-parsing vars,
   even when only one source exists
 - Fixed group modify bug, avoid sending unwanted fields in modify requests
+- Added ability to declare user organization admin
 
 2.3.0 (2015-10-20)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ A few potential uses include:
    Bamboo, etc)
 -  Checking on job statuses
 -  Rapidly creating objects like organizations, users, teams, and more
+-  Pull in `dynamic inventory scripts </docs/inventory_script.rst>`__
+   from Ansible Tower .
 
 Installation
 ------------

--- a/docs/examples/fake_data_creator.sh
+++ b/docs/examples/fake_data_creator.sh
@@ -106,17 +106,17 @@ tower-cli credential create --name=user2 --username=user2 --password=pass1 --tea
 
 echo "Tower-CLI DATA FAKER: creating inventories and groups"
 # Basic localhost examples
-tower-cli inventory create --name=localhost --description="local machine" --organization=Default --variables="variables.yml"
-tower-cli host create --name="127.0.0.1" --description="the host in localhost" --inventory="localhost" --variables="variables.yml"
+tower-cli inventory create --name=localhost --description="local machine" --organization=Default --variables="@variables.yml"
+tower-cli host create --name="127.0.0.1" --description="the host in localhost" --inventory="localhost" --variables="@variables.yml"
 # Corporate example uses localhost with special vars for testing
-tower-cli inventory create --name=Production --description="Production Machines" --organization="Hyrule Ventures" --variables="variables.yml"
+tower-cli inventory create --name=Production --description="Production Machines" --organization="Hyrule Ventures" --variables="@variables.yml"
 tower-cli group create --name=EC2 --credential="AWS creds" --source=ec2 --description="EC2 hosts" --inventory=Production
 tower-cli group create --name=RAX --credential="RAX creds" --source=rax --description="RAX hosts" --inventory=Production
 # EC2vars demonstrates the use of advanced source variables
 tower-cli group create --name=EC2vars --credential="AWS creds" --source=ec2 --description="EC2 hosts" --inventory=Production --source-regions="us-east-1" --overwrite=true --overwrite-vars=false --source-vars="foo: bar"
 # Another example
-tower-cli inventory create --name="Testing" --description="Test Machines" --organization="Bio Inc" --variables="variables.yml"
-tower-cli group create --name=web --source=manual --inventory=Testing --variables="variables.yml"
+tower-cli inventory create --name="Testing" --description="Test Machines" --organization="Bio Inc" --variables="@variables.yml"
+tower-cli group create --name=web --source=manual --inventory=Testing --variables="@variables.yml"
 tower-cli host create --name="10.42.0.6" --inventory=Testing
 tower-cli host create --name="10.42.0.7" --inventory=Testing
 tower-cli host create --name="10.42.0.8" --inventory=Testing
@@ -124,10 +124,10 @@ tower-cli host create --name="10.42.0.9" --inventory=Testing
 tower-cli host create --name="10.42.0.10" --inventory=Testing
 # Another inventory, but with recursive structure
 # these include databases and web servers, with hosts in the web server group
-tower-cli inventory create --name=QA --description="QA Machines" --organization=Default --variables="variables.yml"
-tower-cli group create --name="databases" --source=manual --inventory=QA --variables="variables.yml"
+tower-cli inventory create --name=QA --description="QA Machines" --organization=Default --variables="@variables.yml"
+tower-cli group create --name="databases" --source=manual --inventory=QA --variables="@variables.yml"
 # Setting up the web servers, associate hosts with the group
-tower-cli group create --name="web servers" --source=manual --inventory=QA --variables="variables.yml"
+tower-cli group create --name="web servers" --source=manual --inventory=QA --variables="@variables.yml"
 tower-cli host create --name="server.example1.com" --inventory=QA
 tower-cli host associate --host="server.example1.com" --group="web servers"
 tower-cli host create --name="server.example2.com" --inventory=QA

--- a/docs/examples/teardown_script.sh
+++ b/docs/examples/teardown_script.sh
@@ -43,10 +43,10 @@ tower-cli project delete --name="Ansible Examples"
 echo "Tower-CLI DATA FAKER: deleting orgs and teams"
 # Teams do not automatically go away when their organization is deleted
 # so we must delete them all
-tower-cli team delete --name Ops
-tower-cli team delete --name QA
-tower-cli team delete --name Dev
-tower-cli team delete --name Engineering
-tower-cli team delete --name "Tech Services"
+tower-cli team delete --name Ops --organization=Default
+tower-cli team delete --name QA --organization=Default
+tower-cli team delete --name Dev --organization=Default
+tower-cli team delete --name Engineering --organization="Bio Inc"
+tower-cli team delete --name "Tech Services" --organization="Bio Inc"
 tower-cli organization delete --name="Hyrule Ventures"
 tower-cli organization delete --name="Bio Inc"

--- a/docs/inventory_script.rst
+++ b/docs/inventory_script.rst
@@ -1,0 +1,43 @@
+Inventory Script Subcommand
+===========================
+
+The inventory script subcommand returns the output of dynamic inventory
+scripts in JSON format by default. It can be invoked by either the primary
+key or another set of parameters that uniquely specifies the inventory.
+
+For example, if the inventory was named "QA_machines" and had an primary
+key of 12, either of the following commands would be valid:
+
+.. code:: bash
+
+    $ tower-cli inventory script --name="QA_machines"
+
+    $ tower-cli inventory script 12
+
+These commands will return text in JSON format.
+
+Example Usage
+-------------
+
+As a part of bash scripting (or some other automated workflow), this
+command can be leveraged to feed dynamic inventory into Ansible locally
+from Ansible Tower.
+
+Tower-cli will can act as a stand-in for a script that dynamically defines
+inventory. For example, consider the following file named `tower-inventory.sh`.
+
+.. code:: bash
+
+    #!/bin/bash
+
+    tower-cli inventory script $TOWER_INVENTORY_ID --hostvars=1
+
+While in the same directory, the following command will list the hosts via
+Ansible in its command-line usage.
+
+.. code:: bash
+
+    TOWER_INVENTORY_ID=12 ansible -i tower-inventory.sh all --list-hosts
+
+Assuming the inventory pk is 12, this will give a list of hosts in that
+inventory.

--- a/docs/inventory_script.rst
+++ b/docs/inventory_script.rst
@@ -5,12 +5,16 @@ The inventory script subcommand returns the output of dynamic inventory
 scripts in JSON format by default. It can be invoked by either the primary
 key or another set of parameters that uniquely specifies the inventory.
 
-For example, if the inventory was named "QA_machines" and had an primary
-key of 12, either of the following commands would be valid:
+For example, if the inventory was named ``QA_machines`` and had an primary
+key of ``12``, either of the following commands would be valid:
 
 .. code:: bash
 
     $ tower-cli inventory script --name="QA_machines"
+
+or
+
+.. code:: bash
 
     $ tower-cli inventory script 12
 
@@ -24,7 +28,8 @@ command can be leveraged to feed dynamic inventory into Ansible locally
 from Ansible Tower.
 
 Tower-cli will can act as a stand-in for a script that dynamically defines
-inventory. For example, consider the following file named `tower-inventory.sh`.
+inventory. For example, consider the following file
+named ```tower-inventory.sh``.
 
 .. code:: bash
 

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -227,7 +227,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                             else None,
                             help=field.help,
                             type=field.type,
-                            show_default=field.show_default
+                            show_default=field.show_default,
+                            cls=field.cls
                         )(new_method)
 
                 # Make a click Command instance using this method

--- a/lib/tower_cli/models/fields.py
+++ b/lib/tower_cli/models/fields.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import six
+from click import Option
+from tower_cli.utils.types import VariableOption
 
 
 _field_counter = 0
@@ -26,7 +28,8 @@ class Field(object):
     def __init__(self, key=None, type=six.text_type, default=None,
                  display=True, filterable=True, help_text=None,
                  is_option=True, password=False, read_only=False,
-                 required=True, show_default=False, unique=False):
+                 required=True, show_default=False, unique=False,
+                 yaml_vars=False):
         # Init the name to blank.
         # What's going on here: This is set by the ResourceMeta metaclass
         # when the **resource** is instantiated.
@@ -47,6 +50,10 @@ class Field(object):
         self.required = required
         self.show_default = show_default
         self.unique = unique
+        if yaml_vars:
+            self.cls = VariableOption
+        else:
+            self.cls = Option
 
         # If this is a password, display is always off.
         if self.password:

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -74,6 +74,8 @@ class Resource(models.ExeResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `monitor` on the newly '
                        'launched command rather than exiting with a success.')
+    @click.option('--stdout', is_flag=True,
+                  help='Stream the standard out from the Tower server.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this attempt'
                        ' will time out after the given number of seconds. '
@@ -81,7 +83,8 @@ class Resource(models.ExeResource):
     @click.option('--become', required=False, is_flag=True,
                   help='If used, privledge escalation will be enabled for '
                        'this command.')
-    def launch(self, monitor=False, timeout=None, become=False, **kwargs):
+    def launch(self, monitor=False, stdout=False, timeout=None,
+               become=False, **kwargs):
         """Launch a new ad-hoc command.
 
         Runs a user-defined command from Ansible Tower, immediately starts it,
@@ -111,7 +114,7 @@ class Resource(models.ExeResource):
         # If we were told to monitor the command once it started, then call
         # monitor from here.
         if monitor:
-            return self.monitor(command_id, timeout=timeout)
+            return self.monitor(command_id, timeout=timeout, stdout=stdout)
 
         # Return the command ID and other response data
         answer = OrderedDict((

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -18,6 +18,7 @@ import click
 from tower_cli import get_resource, models, resources
 from tower_cli.api import client
 from tower_cli.utils import exceptions as exc, types
+from tower_cli.utils.types import VariableOption
 
 INVENTORY_SOURCES = ['manual', 'ec2', 'rax', 'vmware',
                      'gce', 'azure', 'openstack']
@@ -31,8 +32,7 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
-    variables = models.Field(type=types.File('r'), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)
 
     # Basic options for the source
     @click.option('--credential', type=types.Related('credential'),
@@ -44,7 +44,7 @@ class Resource(models.Resource):
     @click.option('--source-regions', help='Regions for your cloud provider.')
     # Options may not be valid for certain types of cloud servers
     @click.option('--source-vars', help='Override variables found on source '
-                  'with variables defined in this field.')
+                  'with variables defined in this field.', cls=VariableOption)
     @click.option('--overwrite', type=bool,
                   help='Delete child groups and hosts not found in source.')
     @click.option('--overwrite-vars', type=bool,
@@ -107,7 +107,7 @@ class Resource(models.Resource):
     @click.option('--source-regions', help='Regions for your cloud provider.')
     # Options may not be valid for certain types of cloud servers
     @click.option('--source-vars', help='Override variables found on source '
-                  'with variables defined in this field.')
+                  'with variables defined in this field.', cls=VariableOption)
     @click.option('--overwrite', type=bool,
                   help='Delete child groups and hosts not found in source.')
     @click.option('--overwrite-vars', type=bool,

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -28,8 +28,7 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
     enabled = models.Field(type=bool, required=False)
-    variables = models.Field(type=types.File('r'), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)
 
     @resources.command(use_fields_as_options=False)
     @click.option('--host', type=types.Related('host'))

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -25,5 +25,4 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
-    variables = models.Field(type=models.File('r'), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -35,14 +35,16 @@ class Resource(models.Resource):
     @click.option('--hostvars', required=False, type=int,
                   help='Set to 1 to include host variables')
     def script(self, pk=None, format='json', **kwargs):
-        """Return the script output for an inventory."""
+        """Return Ansible dynamic inventory script output."""
 
         # set runtime value of format setting
         settings.format = format
 
         # pull out dictionary of values to pass in request
+        # also necessary in order to remove the script-specific parameters
+        # from the dictionary used for the inventory lookup
         payload = dict(
-            (k, kwargs[k]) for k in ['hostvars'] if k in kwargs
+            (k, kwargs.pop(k)) for k in ['hostvars'] if k in kwargs
         )
 
         # if primary key not given, look up via the standard get routine

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tower_cli import models
-from tower_cli.utils import types
+import click
+
+from tower_cli import models, resources
+from tower_cli.utils import types, debug
+from tower_cli.api import client
+from tower_cli.conf import settings
 
 
 class Resource(models.Resource):
@@ -26,3 +30,30 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
     variables = models.Field(required=False, display=False, yaml_vars=True)
+
+    @resources.command
+    @click.option('--hostvars', required=False, type=int,
+                  help='Set to 1 to include host variables')
+    def script(self, pk=None, format='json', **kwargs):
+        """Return the script output for an inventory."""
+
+        # set runtime value of format setting
+        settings.format = format
+
+        # pull out dictionary of values to pass in request
+        payload = dict(
+            (k, kwargs[k]) for k in ['hostvars'] if k in kwargs
+        )
+
+        # if primary key not given, look up via the standard get routine
+        if not pk:
+            get_resp = self.get(**kwargs)
+            pk = get_resp['id']
+
+        # make the request to /inventories/pk/script/
+        debug.log('Getting script for inventory.', header='details')
+        script_url = '%s%d/script/' % (self.endpoint, pk)
+        r = client.get(script_url, params=payload)
+        resp = r.json()
+
+        return resp

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -36,7 +36,7 @@ class Resource(models.MonitorableResource):
     )
     source_regions = models.Field(required=False, display=False)
     # Variables not shared by all cloud providers
-    source_vars = models.Field(required=False, display=False)
+    source_vars = models.Field(required=False, display=False, yaml_vars=True)
     # Boolean variables
     overwrite = models.Field(type=bool, required=False, display=False)
     overwrite_vars = models.Field(type=bool, required=False, display=False)

--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -1,0 +1,135 @@
+# Copyright 2015, Ansible, Inc.
+# Luke Sneeringer <lsneeringer@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from tower_cli import models, resources
+from tower_cli.utils import types, debug, exceptions as exc
+
+
+class Resource(models.Resource):
+    cli_help = 'Manage permissions within Ansible Tower.'
+    endpoint = '/permissions/'
+    identity = ('name', )
+
+    # Permissions must be created for either a user or a team
+    name = models.Field(unique=True, required=False, display=True)
+    user = models.Field(
+        type=types.Related('user'), required=False,
+        display=True, help_text='User to grant permission to.')
+    team = models.Field(
+        type=types.Related('team'), required=False,
+        display=True,
+        help_text='Team to grant permission to '
+                  '(will apply to all members).')
+
+    # Descriptive fields - not in identity or a parent resource
+    description = models.Field(required=False, display=False)
+    project = models.Field(
+        type=types.Related('project'), required=False,
+        display=True, help_text='Allows team/user access to this project.')
+    inventory = models.Field(
+        type=types.Related('inventory'), required=False,
+        display=True, help_text='Allows team/user access to this inventory.')
+    permission_type = models.Field(
+        help_text='The level of access granted.',
+        type=click.Choice(
+            ["read", "write", "admin", "run", "check", "scan", "create"]))
+    run_ad_hoc_commands = models.Field(
+        type=bool, required=False, display=False,
+        help_text='If "true", includes permission to run ad hoc commands')
+
+    def get_base_url(self, user, team):
+        """Return a string that specifies the endpoint to use"""
+        if not user and not team:
+            raise exc.TowerCLIError('Specify either a user or a team.')
+        elif user:
+            return '/users/%d/permissions/' % user
+        else:
+            return '/teams/%d/permissions/' % team
+
+    def get_permission_pk(self, pk, user, team, **kwargs):
+        """Return the pk with a search method specific to permissions."""
+        if not pk:
+            self.endpoint = self.get_base_url(user, team)
+            debug.log('Checking for an existing record.', header='details')
+            existing_data = self._lookup(
+                fail_on_found=False, fail_on_missing=True,
+                include_debug_header=False, **kwargs)
+            return existing_data['id']
+        else:
+            return pk
+
+    def create(self, user=None, team=None, **kwargs):
+        """Create a permission. Provide one of each:
+              Permission granted to: user or team.
+              Permission to: inventory or project."""
+        self.endpoint = self.get_base_url(user, team)
+        # Apply default specific to creation
+        if not kwargs.get('permission_type', None):
+            kwargs['permission_type'] = 'read'
+        return super(Resource, self).create(**kwargs)
+
+    def modify(self, pk=None, user=None, team=None, **kwargs):
+        """Modify an already existing permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+
+        To modify unique fields, you must use the primary key for the lookup.
+        """
+        # Use the user-based or team-based endpoint to search for record
+        pk = self.get_permission_pk(pk, user, team, **kwargs)
+        # Now use the permission-based endpoint to modify the record
+        self.endpoint = '/permissions/'
+        return super(Resource, self).modify(pk=pk, **kwargs)
+
+    def delete(self, pk=None, user=None, team=None, **kwargs):
+        """Remove the given permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+
+        If `fail_on_missing` is True, then the permission's not being found is
+        considered a failure; otherwise, a success with no change is reported.
+        """
+        # Use the user-based or team-based endpoint to search for record
+        pk = self.get_permission_pk(pk, user, team, **kwargs)
+        # Now use the permission-based endpoint to delete the record
+        self.endpoint = '/permissions/'
+        return super(Resource, self).delete(pk=pk, **kwargs)
+
+    @resources.command(ignore_defaults=True)
+    def get(self, pk=None, user=None, team=None, **kwargs):
+        """Return one and exactly one permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+        """
+        self.endpoint = self.get_base_url(user, team)
+        return super(Resource, self).get(pk=pk, **kwargs)
+
+    @resources.command(ignore_defaults=True, no_args_is_help=False)
+    def list(self, user=None, team=None, all_pages=False, **kwargs):
+        """Return a list of permissions, specific to given user or team.
+
+        If one or more filters are provided through keyword arguments,
+        filter the results accordingly.
+
+        If no filters are provided, return all results. But you still must
+        give a user or team because a global listing is not allowed.
+        """
+        self.endpoint = self.get_base_url(user, team)
+        return super(Resource, self).list(all_pages=all_pages, **kwargs)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -119,10 +119,10 @@ def process_extra_vars(extra_vars_list, force_json=True):
             opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
         # Rolling YAML-based string combination
         if any(line.startswith("#") for line in extra_vars_opt.split('\n')):
-            extra_vars_yaml += extra_vars_opt + "\n"
+            extra_vars_yaml += extra_vars_opt.strip("\n") + "\n"
         elif extra_vars_opt != "":
             extra_vars_yaml += yaml.dump(
-                opt_dict, default_flow_style=False) + "\n"
+                opt_dict, default_flow_style=False).strip("\n") + "\n"
         # Combine dictionary with cumulative dictionary
         extra_vars.update(opt_dict)
 

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -127,7 +127,7 @@ class LaunchTests(unittest.TestCase):
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.launch(inventory=1, machine_credential=2,
                                 module_args="echo 'hi'", monitor=True)
-                monitor.assert_called_once_with(42, timeout=None)
+                monitor.assert_called_once_with(42, timeout=None, stdout=False)
 
 
 class StatusTests(unittest.TestCase):

--- a/tests/test_resources_inventory_script.py
+++ b/tests/test_resources_inventory_script.py
@@ -1,0 +1,50 @@
+# Copyright 2015, Red Hat, Inc.
+# Alan Rominger <arominger@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+
+from tests.compat import unittest
+
+
+class UpdateTests(unittest.TestCase):
+    """A set of tests for inventory script retrevial
+    tower-cli inventory script inventory_id
+    """
+    def setUp(self):
+        self.inventory = tower_cli.get_resource('inventory')
+
+    def test_lookup_pk(self):
+        """Test retrevial of an inventory script output by its pk
+        """
+        result_dict = {'all': {'hosts': []}}
+        with client.test_mode as t:
+            t.register_json('/inventories/12/script/',
+                            result_dict, method='GET')
+            result = self.inventory.script(pk=12)
+            assert result == result_dict
+
+    def test_lookup_name(self):
+        """Test retrevial of an inventory script output by its name
+        """
+        result_dict = {'all': {'hosts': []}}
+        with client.test_mode as t:
+            t.register_json('/inventories/12/script/',
+                            result_dict, method='GET')
+            t.register_json(
+                '/inventories/', {'count': 1, 'results': [{'id': 12}]},
+                method='GET')
+            result = self.inventory.script(name='foobar_inventory')
+            assert result == result_dict

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -81,6 +81,16 @@ def jt_vars_registration(t, extra_vars):
                     method='POST')
 
 
+def monitor_registration(t):
+    """ Endpoints common to any monitoring task are registered here. """
+
+    # Do standard registration first
+    standard_registration(t)
+
+    # Endpoint used for standard out streaming
+    t.register_json('/jobs/42/stdout/', {'content': ''})
+
+
 class LaunchTests(unittest.TestCase):
     """A set of tests for ensuring that the job resource's launch command
     works in the way we expect.
@@ -135,10 +145,10 @@ class LaunchTests(unittest.TestCase):
         any invocation-time input, and that monitor is called if requested.
         """
         with client.test_mode as t:
-            standard_registration(t)
+            monitor_registration(t)
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.launch(1, monitor=True)
-                monitor.assert_called_once_with(42, timeout=None)
+                monitor.assert_called_once_with(42, timeout=None, stdout=False)
 
     def test_extra_vars_at_runtime(self):
         """Establish that if we should be asking for extra variables at


### PR DESCRIPTION
This adds the `script` subcommand to the inventory resource, it is used in the following way:

> $ tower-cli inventory script 12 --hostvars=1

Unlike other commands, the default format is json, which is done because most foreseeable uses will use this type of output, and the "human" output does not look very polished.

Packaged along with this, we also have tests for 100% coverage of inventory.py, along with some documentation.

I would have preferred to have hostvars default set 1, but there was no simple way to accomplish this while still preserving the user's ability to turn it off (no way which also didn't involve more tests). Thus, I'm going with this as the most elegant solution that we can pull off. If there are any more options to be added, I would love to add them, but the OPTIONS didn't give anything useful and no testing seemed fruitful. The tower-cli command still has many other options which are either appended as baggage in lower-level wrappers, or for the ability to look up an inventory by name.

Fixes #89 