### PR TITLE
Change extra_vars default behavior for 2.3.1 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ Release History
 ------------------
 
 - Fixed bug affecting force-on-exists and fail_on_found options
+- Changed extra_vars behavior to be more compliant by re-parsing vars,
+  even when only one source exists
 
 2.3.0 (2015-10-20)
 ------------------

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -102,16 +102,19 @@ class Resource(models.ExeResource):
         # do so (unless --no-input is set).
         if data.pop('ask_variables_on_launch', False) and not no_input \
                 and not extra_vars:
-            initial = data['extra_vars']
+            initial = data['extra_vars']  # TODO: convert into key=value pairs
             initial = '\n'.join((
                 '# Specify extra variables (if any) here.',
                 '# Lines beginning with "#" are ignored.',
                 initial,
             ))
             extra_vars = click.edit(initial) or ''
-            extra_vars = '\n'.join([i for i in extra_vars.split('\n')
-                                    if not i.startswith('#')])
-            data['extra_vars'] = extra_vars
+            data['extra_vars'] = parser.extra_vars_loader_wrapper(
+                [i for i in extra_vars.split('\n') if not i.startswith('#')]
+            )
+            # extra_vars = '\n'.join([i for i in extra_vars.split('\n')
+            #                         if not i.startswith('#')])
+            # data['extra_vars'] = extra_vars
 
         # In Tower 2.1 and later, we create the new job with
         # /job_templates/N/launch/; in Tower 2.0 and before, there is a two

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -82,10 +82,10 @@ class Resource(models.Resource):
         You may only include one --extra-vars flag with this command, and
         whatever you provde will overwrite the existing field. Start this
         with @ in order to indicate a filename."""
-        if 'extra_vars' in kwargs:
+        if kwargs.get('extra_vars'):
             # read from file, if given
             kwargs['extra_vars'] = \
-                parser.file_or_yaml_split(kwargs['extra_vars'])
+                parser.extra_vars_loader_wrapper([kwargs['extra_vars']])
         return super(Resource, self).modify(
             pk=pk, create_on_missing=create_on_missing, **kwargs
         )

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -58,11 +58,14 @@ class Resource(models.Resource):
     job_tags = models.Field(required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(required=False, display=False)
+    ask_variables_on_launch = models.Field(
+        type=bool, required=False, display=False,
+        help_text='Prompt user for extra_vars on launch.')
     become_enabled = models.Field(type=bool, required=False, display=False)
 
     @click.option('--extra-vars', required=False, multiple=True,
-                  help='yaml format text that contains extra variables '
-                       'to pass on. Use @ to get these from a file.')
+                  help='Extra variables used by Ansible in YAML or key=value '
+                       'format. Use @ to get YAML from a file.')
     def create(self, fail_on_found=False, force_on_exists=False,
                extra_vars=None, **kwargs):
         """Create a job template.
@@ -71,21 +74,28 @@ class Resource(models.Resource):
         with @ in order to indicate a filename."""
         if extra_vars:
             # combine sources of extra variables, if given
-            kwargs['extra_vars'] = parser.extra_vars_loader_wrapper(extra_vars)
+            kwargs['extra_vars'] = parser.process_extra_vars(
+                extra_vars, force_json=False
+            )
         return super(Resource, self).create(
             fail_on_found=fail_on_found, force_on_exists=force_on_exists,
             **kwargs
         )
 
-    def modify(self, pk=None, create_on_missing=False, **kwargs):
+    @click.option('--extra-vars', required=False, multiple=True,
+                  help='Extra variables used by Ansible in YAML or key=value '
+                       'format. Use @ to get YAML from a file.')
+    def modify(self, pk=None, create_on_missing=False,
+               extra_vars=None, **kwargs):
         """Modify a job template.
-        You may only include one --extra-vars flag with this command, and
-        whatever you provde will overwrite the existing field. Start this
+        You may include multiple --extra-vars flags in order to combine
+        different sources of extra variables. Start this
         with @ in order to indicate a filename."""
-        if kwargs.get('extra_vars'):
-            # read from file, if given
-            kwargs['extra_vars'] = \
-                parser.extra_vars_loader_wrapper([kwargs['extra_vars']])
+        if extra_vars:
+            # combine sources of extra variables, if given
+            kwargs['extra_vars'] = parser.process_extra_vars(
+                extra_vars, force_json=False
+            )
         return super(Resource, self).modify(
             pk=pk, create_on_missing=create_on_missing, **kwargs
         )

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -141,14 +141,6 @@ def load_extra_vars(extra_vars_list):
 
 
 def extra_vars_loader_wrapper(extra_vars_list):
-    """Specific to tower-cli, this avoids altering the extra_vars list
-    if there is only one element in it. This keeps comments and formatting
-    in-tact when passing the information on to the Tower server."""
-    # If there is only one set of extra_vars, then pass it  to the API
-    # without alteration
+    """Dumps the parsed output into a string."""
     extra_vars_dict = load_extra_vars(extra_vars_list)
-    if len(extra_vars_list) == 1:
-        return file_or_yaml_split(extra_vars_list[0])
-    # For a single string of extra_vars, combine them into a single input
-    else:
-        return json.dumps(extra_vars_dict)
+    return json.dumps(extra_vars_dict)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -138,9 +138,10 @@ def process_extra_vars(extra_vars_list, force_json=True):
             opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
         # Rolling YAML-based string combination
         if any(line.startswith("#") for line in extra_vars_opt.split('\n')):
-            extra_vars_yaml += extra_vars_opt
+            extra_vars_yaml += extra_vars_opt + "\n"
         elif extra_vars_opt != "":
-            extra_vars_yaml += yaml.dump(opt_dict, default_flow_style=False)
+            extra_vars_yaml += yaml.dump(
+                opt_dict, default_flow_style=False) + "\n"
         # Combine dictionary with cumulative dictionary
         revised_update(extra_vars, opt_dict)
 
@@ -151,7 +152,7 @@ def process_extra_vars(extra_vars_list, force_json=True):
             try_dict = yaml.load(extra_vars_yaml)
             assert type(try_dict) is dict
             debug.log('Using unprocessed YAML', header='decision', nl=2)
-            return extra_vars_yaml
+            return extra_vars_yaml.rstrip()
         except:
             debug.log('Failed YAML parsing, defaulting to JSON',
                       header='decison', nl=2)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -50,7 +50,7 @@ def parse_kv(var_string):
             token = unicode(token)
         # Look for key=value pattern, if not, process as raw parameter
         if '=' in token:
-            (k, v) = token.split('=')
+            (k, v) = token.split('=', 1)
             # If '=' are unbalanced, then stop and warn user
             if len(k) == 0 or len(v) == 0:
                 raise Exception
@@ -60,20 +60,8 @@ def parse_kv(var_string):
             except:
                 return_dict[k] = v
         else:
-
-            # If there are spaces in the statement, there would be no way
-            # split it from the rest of the text later, so check for that here
-            if " " in token:
-                token = '"' + token + '"'
-            # If token is clearly a failed JSON or YAML string, don't advance
-            if token.endswith(":"):
-                raise Exception
-            # Append the value onto the special key entry _raw_params
-            # this uses a space delimiter
-            if '_raw_params' in return_dict:
-                return_dict['_raw_params'] += " " + token
-            else:
-                return_dict['_raw_params'] = token
+            # scenario where --extra-vars=42, will throw error
+            raise Exception
 
     return return_dict
 
@@ -108,13 +96,6 @@ def string_to_dict(var_string, allow_kv=True):
     return return_dict
 
 
-def revised_update(dict1, dict2):
-    """Updates dict1 with dict2 while appending the elements in _raw_params"""
-    if '_raw_params' in dict2 and '_raw_params' in dict1:
-        dict1['_raw_params'] += " " + str(dict2.pop('_raw_params'))
-    return dict1.update(dict2)
-
-
 def process_extra_vars(extra_vars_list, force_json=True):
     """Returns a string that is valid JSON or YAML and contains all the
     variables in every extra_vars_opt inside of extra_vars_list.
@@ -143,7 +124,7 @@ def process_extra_vars(extra_vars_list, force_json=True):
             extra_vars_yaml += yaml.dump(
                 opt_dict, default_flow_style=False) + "\n"
         # Combine dictionary with cumulative dictionary
-        revised_update(extra_vars, opt_dict)
+        extra_vars.update(opt_dict)
 
     # Return contents in form of a string
     if not force_json:

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -118,7 +118,7 @@ class LaunchTests(unittest.TestCase):
         with client.test_mode as t:
             t.register_json('/job_templates/1/', {
                 'ask_variables_on_launch': True,
-                'extra_vars': 'spam: eggs',
+                'extra_vars': '{"spam": "eggs"}',
                 'id': 1,
                 'name': 'frobnicate',
                 'related': {'launch': '/job_templates/1/launch/'},
@@ -132,11 +132,11 @@ class LaunchTests(unittest.TestCase):
                 edit.return_value = '# Nothing.\nfoo: bar'
                 result = self.res.launch(1, no_input=False)
                 self.assertTrue(
-                    edit.mock_calls[0][1][0].endswith('spam: eggs'),
+                    edit.mock_calls[0][1][0].endswith('{"spam": "eggs"}'),
                 )
-            self.assertEqual(
-                json.loads(t.requests[3].body)['extra_vars'],
-                'foo: bar',
+            self.assertDictContainsSubset(
+                {'foo': 'bar'},
+                json.loads(json.loads(t.requests[3].body)['extra_vars'])
             )
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
 
@@ -208,11 +208,11 @@ class LaunchTests(unittest.TestCase):
                 edit.return_value = '# Nothing.\nfoo: bar'
                 result = self.res.launch(1, no_input=False)
                 self.assertTrue(
-                    edit.mock_calls[0][1][0].endswith('spam: eggs'),
+                    edit.mock_calls[0][1][0].endswith('{"spam": "eggs"}'),
                 )
-            self.assertEqual(
-                json.loads(t.requests[2].body)['extra_vars'],
-                'foo: bar',
+            self.assertDictContainsSubset(
+                {'foo': 'bar'},
+                json.loads(json.loads(t.requests[2].body)['extra_vars'])
             )
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
 
@@ -232,9 +232,9 @@ class LaunchTests(unittest.TestCase):
                             method='POST')
             result = self.res.launch(1, extra_vars=['foo: bar'])
 
-            self.assertEqual(
-                json.loads(t.requests[2].body)['extra_vars'],
-                'foo: bar',
+            self.assertDictContainsSubset(
+                {'foo': 'bar'},
+                json.loads(json.loads(t.requests[2].body)['extra_vars'])
             )
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
 
@@ -254,9 +254,9 @@ class LaunchTests(unittest.TestCase):
                             method='POST')
             result = self.res.launch(1, extra_vars=['foo: bar'])
 
-            self.assertEqual(
-                json.loads(t.requests[2].body)['extra_vars'],
-                'foo: bar',
+            self.assertDictContainsSubset(
+                {'foo': 'bar'},
+                json.loads(json.loads(t.requests[2].body)['extra_vars'])
             )
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
 

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -116,6 +116,7 @@ class LaunchTests(unittest.TestCase):
         runtime, that we do.
         """
         with client.test_mode as t:
+            # test with JSON job template extra_vars
             t.register_json('/job_templates/1/', {
                 'ask_variables_on_launch': True,
                 'extra_vars': '{"spam": "eggs"}',
@@ -131,14 +132,34 @@ class LaunchTests(unittest.TestCase):
             with mock.patch.object(click, 'edit') as edit:
                 edit.return_value = '# Nothing.\nfoo: bar'
                 result = self.res.launch(1, no_input=False)
-                self.assertTrue(
-                    edit.mock_calls[0][1][0].endswith('{"spam": "eggs"}'),
+                self.assertDictContainsSubset(
+                    {"spam": "eggs"},
+                    yaml.load(edit.mock_calls[0][1][0])
                 )
             self.assertDictContainsSubset(
                 {'foo': 'bar'},
                 json.loads(json.loads(t.requests[3].body)['extra_vars'])
             )
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
+
+            # test with YAML and comments
+            t.register_json('/job_templates/1/', {
+                'ask_variables_on_launch': True,
+                'extra_vars': 'spam: eggs\n# comment',
+                'id': 1,
+                'name': 'frobnicate',
+                'related': {'launch': '/job_templates/1/launch/'},
+            })
+            with mock.patch.object(click, 'edit') as edit:
+                edit.return_value = '# Nothing.\nfoo: bar'
+                result = self.res.launch(
+                    1, no_input=False
+                )
+                self.assertIn('# comment', edit.mock_calls[0][1][0])
+                self.assertDictContainsSubset(
+                    {"spam": "eggs"},
+                    yaml.load(edit.mock_calls[0][1][0])
+                )
 
     def test_job_template_variables(self):
         """Establish that job template extra_vars are combined with local
@@ -207,8 +228,9 @@ class LaunchTests(unittest.TestCase):
             with mock.patch.object(click, 'edit') as edit:
                 edit.return_value = '# Nothing.\nfoo: bar'
                 result = self.res.launch(1, no_input=False)
-                self.assertTrue(
-                    edit.mock_calls[0][1][0].endswith('{"spam": "eggs"}'),
+                self.assertDictContainsSubset(
+                    {"spam": "eggs"},
+                    yaml.load(edit.mock_calls[0][1][0])
                 )
             self.assertDictContainsSubset(
                 {'foo': 'bar'},

--- a/tests/test_resources_job_template.py
+++ b/tests/test_resources_job_template.py
@@ -111,7 +111,7 @@ class TemplateTests(unittest.TestCase):
             t.register_json('/job_templates/1/', {'name': 'bar', 'id': 1,
                             'job_type': 'run'},
                             method='PATCH')
-            self.res.modify(name='bar', extra_vars="a: 5")
+            self.res.modify(name='bar', extra_vars=["a: 5"])
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertEqual(t.requests[1].method, 'PATCH')
             self.assertEqual(len(t.requests), 2)

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -52,6 +52,17 @@ class ParserTests(unittest.TestCase):
                 [yaml_w_comment, json_text], force_json=False
             ))
         )
+        # Test that it correctly combines a diverse set of YAML
+        yml1 = "a: 1\n# a comment on second line \nb: 2"
+        yml2 = "c: 3"
+        self.assertEqual(
+            yaml.load(parser.process_extra_vars(
+                [yml1, yml2], force_json=False)),
+            {'a': 1, 'b': 2, 'c': 3}
+        )
+        # make sure it combined them into valid yaml
+        self.assertFalse("{" in parser.process_extra_vars(
+            [yml1, yml2], force_json=False))
 
     def test_combine_raw_params(self):
         """Given multiple files which all have raw parameters, make sure

--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -25,11 +25,6 @@ class ParserTests(unittest.TestCase):
     """A set of tests to establish that the parser methods read files and
     combine variables in the intended way.
     """
-    def test_returns_input_text(self):
-        """Give it only one file, and it should give it right back."""
-        mock_text = "\n\nfoo:   baar\n\n\n"
-        self.assertEqual(mock_text,
-                         parser.extra_vars_loader_wrapper([mock_text]))
 
     def test_many_combinations(self):
         """Combine yaml with json with bare values, check that key:value


### PR DESCRIPTION
If this is confirmed to help with the recent issue #96 about extra_vars parsing, then we should include it in the 2.3.1 release. We will merge this PR, tag, and then release if so.

Fixes #96