### PR TITLE
Modify command bugs resolved

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,13 @@
 Release History
 ===============
 
-2.3.1 (2015-11-24)
+2.3.1 (2015-12-10)
 ------------------
 
 - Fixed bug affecting force-on-exists and fail_on_found options
 - Changed extra_vars behavior to be more compliant by re-parsing vars,
   even when only one source exists
+- Fixed group modify bug, avoid sending unwanted fields in modify requests
 
 2.3.0 (2015-10-20)
 ------------------

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -702,21 +702,6 @@ class ResourceMethods(BaseResource):
         # Done; return the response
         return response
 
-    def create(self, fail_on_found=False, force_on_exists=False, **kwargs):
-        """The code for the create method in a non-command implementation
-        here, so that the child classes can over-ride it as a command,
-        depending on circumstances."""
-        return self.write(create_on_missing=True, fail_on_found=fail_on_found,
-                          force_on_exists=force_on_exists, **kwargs)
-
-    def modify(self, pk=None, create_on_missing=False, **kwargs):
-        """The code for the modify method in a non-command implementation
-        here, so that the child classes can over-ride it as a command,
-        depending on circumstances."""
-        force_on_exists = kwargs.pop('force_on_exists', True)
-        return self.write(pk, create_on_missing=create_on_missing,
-                          force_on_exists=force_on_exists, **kwargs)
-
     def _assoc(self, url_fragment, me, other):
         """Associate the `other` record with the `me` record."""
 
@@ -993,7 +978,8 @@ class Resource(ResourceMethods):
         if a match is found, then no-op (unless `force_on_exists` is set) but
         do not fail (unless `fail_on_found` is set).
         """
-        return super(Resource, self).create(
+        return super(Resource, self).write(
+            create_on_missing=True,
             fail_on_found=fail_on_found, force_on_exists=force_on_exists,
             **kwargs
         )
@@ -1014,6 +1000,5 @@ class Resource(ResourceMethods):
 
         To modify unique fields, you must use the primary key for the lookup.
         """
-        force_on_exists = kwargs.pop('force_on_exists', True)
         return self.write(pk, create_on_missing=create_on_missing,
-                          force_on_exists=force_on_exists, **kwargs)
+                          force_on_exists=True, **kwargs)

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -58,18 +58,19 @@ class Resource(models.Resource):
         """
         # Break out the options for the group vs its inventory_source
         group_fields = [f.name for f in self.fields]
-        inv_kwargs = {}
+        is_kwargs = {}
         for field in kwargs.copy():
             if field not in group_fields:
-                inv_kwargs[field] = kwargs.pop(field)
+                is_kwargs[field] = kwargs.pop(field)
 
         # Handle alias for "manual" source
-        if 'source' in inv_kwargs and inv_kwargs['source'] == 'manual':
-            inv_kwargs.pop('source')
+        if 'source' in is_kwargs and is_kwargs['source'] == 'manual':
+            is_kwargs.pop('source')
 
         # First, create the group.
         answer = super(Resource, self).create(
-            fail_on_found=False, force_on_exists=False, **kwargs)
+            fail_on_found=fail_on_found, force_on_exists=force_on_exists,
+            **kwargs)
 
         # If the group already exists and we aren't supposed to make changes,
         # then we're done.
@@ -80,7 +81,7 @@ class Resource(models.Resource):
         # with the inventory source at all? If no credential or source
         # was specified, then we'd just be updating the inventory source
         # with an effective no-op.
-        if len(inv_kwargs) == 0:
+        if len(is_kwargs) == 0:
             return answer
 
         # Get the inventory source ID ("isid").
@@ -91,11 +92,11 @@ class Resource(models.Resource):
         # We now have our inventory source ID; modify it according to the
         # provided parameters.
         isrc = get_resource('inventory_source')
-        inv_answer = isrc.write(pk=isid, force_on_exists=True, **inv_kwargs)
+        is_answer = isrc.write(pk=isid, force_on_exists=True, **is_kwargs)
 
         # If either the inventory_source or the group objects were modified
         # then refelect this in the output to avoid confusing the user.
-        if inv_answer['changed']:
+        if is_answer['changed']:
             answer['changed'] = True
         return answer
 
@@ -120,22 +121,22 @@ class Resource(models.Resource):
         """
         # Break out the options for the group vs its inventory_source
         group_fields = [f.name for f in self.fields]
-        inv_kwargs = {}
+        is_kwargs = {}
         for field in kwargs.copy():
             if field not in group_fields:
-                inv_kwargs[field] = kwargs.pop(field)
+                is_kwargs[field] = kwargs.pop(field)
 
         # Handle alias for "manual" source
-        if 'source' in inv_kwargs and inv_kwargs['source'] == 'manual':
-            inv_kwargs['source'] = ''
+        if 'source' in is_kwargs and is_kwargs['source'] == 'manual':
+            is_kwargs['source'] = ''
 
         # First, modify the group.
         answer = super(Resource, self).modify(
-            pk=pk, create_on_missing=False, **kwargs)
+            pk=pk, create_on_missing=create_on_missing, **kwargs)
 
         # If the group already exists and we aren't supposed to make changes,
         # then we're done.
-        if len(inv_kwargs) == 0:
+        if len(is_kwargs) == 0:
             return answer
 
         # Get the inventory source ID ("isid").
@@ -149,11 +150,11 @@ class Resource(models.Resource):
         # Note: Any fields that were part of the group modification need
         # to be expunged from kwargs before making this call.
         isrc = get_resource('inventory_source')
-        inv_answer = isrc.write(pk=isid, force_on_exists=True, **inv_kwargs)
+        is_answer = isrc.write(pk=isid, force_on_exists=True, **is_kwargs)
 
         # If either the inventory_source or the group objects were modified
         # then refelect this in the output to avoid confusing the user.
-        if inv_answer['changed']:
+        if is_answer['changed']:
             answer['changed'] = True
         return answer
 

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -64,7 +64,7 @@ class Resource(models.Resource):
                 is_kwargs[field] = kwargs.pop(field)
 
         # Handle alias for "manual" source
-        if 'source' in is_kwargs and is_kwargs['source'] == 'manual':
+        if is_kwargs.get('source', None) == 'manual':
             is_kwargs.pop('source')
 
         # First, create the group.
@@ -127,7 +127,7 @@ class Resource(models.Resource):
                 is_kwargs[field] = kwargs.pop(field)
 
         # Handle alias for "manual" source
-        if 'source' in is_kwargs and is_kwargs['source'] == 'manual':
+        if is_kwargs.get('source', None) == 'manual':
             is_kwargs['source'] = ''
 
         # First, modify the group.

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -56,6 +56,10 @@ class Resource(models.Resource):
         """Create a group and, if necessary, modify the inventory source within
         the group.
         """
+        # Handle alias for "manual" source
+        if source == 'manual':
+            source = ''
+
         # First, create the group.
         answer = super(Resource, self).create(**kwargs)
 
@@ -68,7 +72,7 @@ class Resource(models.Resource):
         # with the inventory source at all? If no credential or source
         # was specified, then we'd just be updating the inventory source
         # with an effective no-op.
-        if not credential and source in ('manual', None):
+        if not credential and source in ('', None):
             return answer
 
         # Get the inventory source ID ("isid").
@@ -101,6 +105,10 @@ class Resource(models.Resource):
         """Modify a group and, if necessary, the inventory source within
         the group.
         """
+        # Handle alias for "manual" source
+        if source == 'manual':
+            source = ''
+
         # First, modify the group.
         answer = super(Resource, self).modify(pk=pk, **kwargs)
 

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -31,7 +31,7 @@ class Resource(models.MonitorableResource):
     source = models.Field(
         default='manual',
         help_text='The type of inventory source in use.',
-        type=click.Choice(['manual', 'ec2', 'rax', 'vmware',
+        type=click.Choice(['', 'ec2', 'rax', 'vmware',
                            'gce', 'azure', 'openstack']),
     )
     source_regions = models.Field(required=False, display=False)

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -29,9 +29,7 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     job_type = models.Field(
-        default='run',
         display=False,
-        show_default=True,
         type=click.Choice(['run', 'check']),
     )
     inventory = models.Field(type=types.Related('inventory'))
@@ -77,6 +75,9 @@ class Resource(models.Resource):
             kwargs['extra_vars'] = parser.process_extra_vars(
                 extra_vars, force_json=False
             )
+        # Provide a default value for job_type, but only in creation of JT
+        if 'job_type' not in kwargs:
+            kwargs['job_type'] = 'run'
         return super(Resource, self).create(
             fail_on_found=fail_on_found, force_on_exists=force_on_exists,
             **kwargs

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -69,7 +69,8 @@ class Resource(models.Resource, models.MonitorableResource):
         to monitor if the flag is set.
         """
         # First, run the create method, ignoring the organization given
-        answer = super(Resource, self).create(
+        answer = super(Resource, self).write(
+            create_on_missing=True,
             fail_on_found=fail_on_found, force_on_exists=force_on_exists,
             **kwargs
         )
@@ -112,8 +113,9 @@ class Resource(models.Resource, models.MonitorableResource):
         # Associated with issue #52, the organization can't be modified
         #    with the 'modify' command. This would create confusion about
         #    whether its flag is an identifier versus a field to modify.
-        return super(Resource, self).modify(
-            pk=pk, create_on_missing=create_on_missing, **kwargs
+        return super(Resource, self).write(
+            pk, create_on_missing=create_on_missing,
+            force_on_exists=True, **kwargs
         )
 
     @resources.command(use_fields_as_options=('name', 'organization'))

--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -70,12 +70,13 @@ class GroupTests(unittest.TestCase):
         with mock.patch.object(models.Resource, 'create') as super_create:
             super_create.return_value = {'changed': False, 'id': 1}
             with client.test_mode as t:
-                answer = self.gr.create(name='Foo', inventory=1,
-                                        credential=None)
+                answer = self.gr.create(name='Foo', inventory=1)
                 self.assertEqual(len(t.requests), 0)
             # This also establishes that the "credential" argument above
             # was dropped at the superclass method (as it should be).
-            super_create.assert_called_once_with(name='Foo', inventory=1)
+            super_create.assert_called_once_with(
+                fail_on_found=False, force_on_exists=False,
+                name='Foo', inventory=1)
             self.assertFalse(answer['changed'])
 
     def test_create_change_but_no_isource_request_needed(self):
@@ -150,10 +151,10 @@ class GroupTests(unittest.TestCase):
         with mock.patch.object(models.Resource, 'modify') as super_modify:
             super_modify.return_value = {'changed': False}
             with client.test_mode as t:
-                self.gr.modify(42, source='rax',
-                               force_on_exists=False)
+                self.gr.modify(42, description='rax')
                 self.assertEqual(len(t.requests), 0)
-            super_modify.assert_called_once_with(pk=42, force_on_exists=False)
+            super_modify.assert_called_once_with(
+                pk=42, create_on_missing=False, description='rax')
 
     def test_modify_with_change(self):
         """Establish that if we attempt to modify a group, that the inventory
@@ -169,7 +170,7 @@ class GroupTests(unittest.TestCase):
                 self.gr.modify(1, name='foo', source='rax')
                 self.assertEqual(len(t.requests), 1)
             isrc_modify.assert_called_once_with(
-                pk=42, source='rax', credential=None, force_on_exists=True,
+                pk=42, source='rax', force_on_exists=True,
             )
 
         # Test than when the group description is changed, we hit the
@@ -202,7 +203,7 @@ class GroupTests(unittest.TestCase):
                 self.gr.modify(1, name='foo', source='manual')
                 self.assertEqual(len(t.requests), 1)
             isrc_modify.assert_called_once_with(
-                pk=42, source='', credential=None, force_on_exists=True,
+                pk=42, source='', force_on_exists=True,
             )
 
     def test_sync(self):


### PR DESCRIPTION
As referenced in the respective issue, this deals mainly with two problems. 1) `tower-cli group modify` will error 2) `tower-cli job_template modify` will silently modify things that it shouldn't. These both relate to hazards with setting defaults that also apply to the `modify` command. To explain that better, I would distinguish between command-line-level defaults, and defaults for a specific method. When you set a default on a field inside of a class, it's not exactly clear what the intention is.

# Group Modify Fix

This command takes two actions - first it modifies the group, then it modifies the group's connected inventory_source. The problem is that the `--source` option on the group modify commands was set to an invalid value as a default, so so it would fail without that option specified. Since this was implemented with a click.option decorator, it can just be removed from the modify command and not the create command.

Another minor issue is that the result would appear green (represents unchanged) when it should have appeared yellow (changed). That is because it modifies two things in the method. A a quick fix, I set it to output whenever of the two changed. If they both changed, it doesn't matter much, because the information displayed to the user isn't very different between the two.

# Job Template Fix

Previously, `job_type` had its default set to `run`. You can still create a JT and set job_type to check, but if you then edit something unrelated in this JT (like its description), it would set the job_type back to run. We would like to change the logic more broadly so that we can still use field defaults in this way, but it doesn't go well. If a JT has its job_type set to check, and then it is modified, there is no way for the method `write` in `base.py` to tell if that was a user input, or if it was passed as a default. Thus, we can't really fix the issue on this level.

The simple solution is to have a special clause in creation of a job template that sets the job_type if none is given. That is the solution I went with.

Fixes #98