### PR TITLE
Bug fixes revealed in pre-release testing

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -93,7 +93,7 @@ class Resource(models.ExeResource):
 
         # Add the runtime extra_vars to this list
         if extra_vars:
-            extra_vars_list += extra_vars
+            extra_vars_list += list(extra_vars)  # accept tuples
 
         # If the job template requires prompting for extra variables,
         # do so (unless --no-input is set).
@@ -109,7 +109,12 @@ class Resource(models.ExeResource):
                 initial,
             ))
             extra_vars = click.edit(initial) or ''
-            extra_vars_list = [extra_vars]
+            if extra_vars != initial:
+                extra_vars_list = [extra_vars]
+
+        # Data is starting out with JT variables, and we only want to
+        # include extra_vars that come from the algorithm here.
+        data.pop('extra_vars', None)
 
         # Dump extra_vars into JSON string for launching job
         if len(extra_vars_list) > 0:

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -76,7 +76,7 @@ class Resource(models.Resource):
                 extra_vars, force_json=False
             )
         # Provide a default value for job_type, but only in creation of JT
-        if 'job_type' not in kwargs:
+        if not kwargs.get('job_type', False):
             kwargs['job_type'] = 'run'
         return super(Resource, self).create(
             fail_on_found=fail_on_found, force_on_exists=force_on_exists,

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -121,6 +121,15 @@ class LaunchTests(unittest.TestCase):
                 json.loads(t.requests[2].body)['job_tags'], 'a, b, c',
             )
 
+    def test_launch_w_tuple_extra_vars(self):
+        """Establish that if the click library gives a tuple, than the job
+        will run normally.
+        """
+        with client.test_mode as t:
+            standard_registration(t)
+            result = self.res.launch(1, extra_vars=())
+            self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
+
     def test_basic_launch_monitor_option(self):
         """Establish that we are able to create a job that doesn't require
         any invocation-time input, and that monitor is called if requested.


### PR DESCRIPTION
I went through the full testing suite we have for tower-cli after merging the other 2.3.1 fixes. Doing so, I hit the following bugs, and this PR is intended to fix them:

- When creating a Job Template with no parameters, the method failed to add the 'job_type' field
- If Tower version >2.4 and extra_vars are not specified, it sent the Job Template extra_vars because of the various dictionary juggling going on
- An empty survey resulted in a parsing error, so a special case was added to allow this
- Click library will pass `()` when no extra vars are given, and this will not combine with the list we are building