### PR TITLE
Prototype for user interaction with the survey

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -111,14 +111,8 @@ class Resource(models.ExeResource):
             # Survey questions, variables, types, and defaults
             # added to the editor's initial canvas
             if data.get('survey_enabled', False):
-                initial += '\n# SURVEY QUESTIONS'
-                survey_spec = client.get(
-                    '/job_templates/%s/survey_spec/' % jt['id']).json()
-                for q in survey_spec['spec']:
-                    initial += (
-                        '\n\n# Survey Question: ' +
-                        q['question_name'] + '\n# (' + q['type'] + ')' +
-                        '\n' + q['variable'] + ': ' + str(q['default']))
+                initial += jt_resource.survey_text(
+                    jt['id'], check_enabled=False)
             # Create the extra_vars parameter from the user input
             extra_vars = click.edit(initial) or ''
             if extra_vars != initial:


### PR DESCRIPTION
This is a middle-of-the-ground solution to allow survey questions and defaults to play a role in tower-cli. The click.edit method will open up the user's default editor in the command line (like vim). There, they can type all of the yaml variables they intend to send as extra_vars.

All this PR does is print out the survey questions and other helpful information in a restricted scenario in a job launch. Invoked with this type of syntax:

    tower-cli job launch --job-template="Hello World with a survey"

The conditions required to be met before tower-cli will attempt to fetch survey questions include:

- The job template has a survey enabled
- The command does not have the `--no-input` flag set
- No other variables are provided via the `--extra-vars` flag

These condition help to keep this behavior narrow and not interfere with automated workflows. Also, while the survey is "interactive" in a way, it is only using the existing tower-cli solution for allowing the user to edit the variables being sent.

Fixes #39 