### PR TITLE
Permission feature added

### DIFF
--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -1,0 +1,135 @@
+# Copyright 2015, Ansible, Inc.
+# Luke Sneeringer <lsneeringer@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from tower_cli import models, resources
+from tower_cli.utils import types, debug, exceptions as exc
+
+
+class Resource(models.Resource):
+    cli_help = 'Manage permissions within Ansible Tower.'
+    endpoint = '/permissions/'
+    identity = ('name', )
+
+    # Permissions must be created for either a user or a team
+    name = models.Field(unique=True, required=False, display=True)
+    user = models.Field(
+        type=types.Related('user'), required=False,
+        display=True, help_text='User to grant permission to.')
+    team = models.Field(
+        type=types.Related('team'), required=False,
+        display=True,
+        help_text='Team to grant permission to '
+                  '(will apply to all members).')
+
+    # Descriptive fields - not in identity or a parent resource
+    description = models.Field(required=False, display=False)
+    project = models.Field(
+        type=types.Related('project'), required=False,
+        display=True, help_text='Allows team/user access to this project.')
+    inventory = models.Field(
+        type=types.Related('inventory'), required=False,
+        display=True, help_text='Allows team/user access to this inventory.')
+    permission_type = models.Field(
+        help_text='The level of access granted.',
+        type=click.Choice(
+            ["read", "write", "admin", "run", "check", "scan", "create"]))
+    run_ad_hoc_commands = models.Field(
+        type=bool, required=False, display=False,
+        help_text='If "true", includes permission to run ad hoc commands')
+
+    def get_base_url(self, user, team):
+        """Return a string that specifies the endpoint to use"""
+        if not user and not team:
+            raise exc.TowerCLIError('Specify either a user or a team.')
+        elif user:
+            return '/users/%d/permissions/' % user
+        else:
+            return '/teams/%d/permissions/' % team
+
+    def get_permission_pk(self, pk, user, team, **kwargs):
+        """Return the pk with a search method specific to permissions."""
+        if not pk:
+            self.endpoint = self.get_base_url(user, team)
+            debug.log('Checking for an existing record.', header='details')
+            existing_data = self._lookup(
+                fail_on_found=False, fail_on_missing=True,
+                include_debug_header=False, **kwargs)
+            return existing_data['id']
+        else:
+            return pk
+
+    def create(self, user=None, team=None, **kwargs):
+        """Create a permission. Provide one of each:
+              Permission granted to: user or team.
+              Permission to: inventory or project."""
+        self.endpoint = self.get_base_url(user, team)
+        # Apply default specific to creation
+        if not kwargs.get('permission_type', None):
+            kwargs['permission_type'] = 'read'
+        return super(Resource, self).create(**kwargs)
+
+    def modify(self, pk=None, user=None, team=None, **kwargs):
+        """Modify an already existing permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+
+        To modify unique fields, you must use the primary key for the lookup.
+        """
+        # Use the user-based or team-based endpoint to search for record
+        pk = self.get_permission_pk(pk, user, team, **kwargs)
+        # Now use the permission-based endpoint to modify the record
+        self.endpoint = '/permissions/'
+        return super(Resource, self).modify(pk=pk, **kwargs)
+
+    def delete(self, pk=None, user=None, team=None, **kwargs):
+        """Remove the given permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+
+        If `fail_on_missing` is True, then the permission's not being found is
+        considered a failure; otherwise, a success with no change is reported.
+        """
+        # Use the user-based or team-based endpoint to search for record
+        pk = self.get_permission_pk(pk, user, team, **kwargs)
+        # Now use the permission-based endpoint to delete the record
+        self.endpoint = '/permissions/'
+        return super(Resource, self).delete(pk=pk, **kwargs)
+
+    @resources.command(ignore_defaults=True)
+    def get(self, pk=None, user=None, team=None, **kwargs):
+        """Return one and exactly one permission.
+
+        Provide pk for permission. Alternatively, provide name and the
+        parent user/team.
+        """
+        self.endpoint = self.get_base_url(user, team)
+        return super(Resource, self).get(pk=pk, **kwargs)
+
+    @resources.command(ignore_defaults=True, no_args_is_help=False)
+    def list(self, user=None, team=None, all_pages=False, **kwargs):
+        """Return a list of permissions, specific to given user or team.
+
+        If one or more filters are provided through keyword arguments,
+        filter the results accordingly.
+
+        If no filters are provided, return all results. But you still must
+        give a user or team because a global listing is not allowed.
+        """
+        self.endpoint = self.get_base_url(user, team)
+        return super(Resource, self).list(all_pages=all_pages, **kwargs)

--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -53,7 +53,10 @@ class Resource(models.Resource):
 
     def get_base_url(self, user, team):
         """Return a string that specifies the endpoint to use"""
-        if not user and not team:
+        if 'user' in self.endpoint or 'team' in self.endpoint:
+            # This function has already been ran, so take no action
+            return self.endpoint
+        elif not user and not team:
             raise exc.TowerCLIError('Specify either a user or a team.')
         elif user:
             return '/users/%d/permissions/' % user
@@ -64,7 +67,7 @@ class Resource(models.Resource):
         """Return the pk with a search method specific to permissions."""
         if not pk:
             self.endpoint = self.get_base_url(user, team)
-            debug.log('Checking for an existing record.', header='details')
+            debug.log('Checking for existing permission.', header='details')
             existing_data = self._lookup(
                 fail_on_found=False, fail_on_missing=True,
                 include_debug_header=False, **kwargs)

--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -1,5 +1,5 @@
-# Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Copyright 2016, Red Hat
+# Alan Rominger <arominge@redhat.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -20,7 +20,12 @@ from tower_cli.utils import types, debug, exceptions as exc
 
 
 class Resource(models.Resource):
-    cli_help = 'Manage permissions within Ansible Tower.'
+    cli_help = (
+        'Manage permissions within Ansible Tower in versions prior to 3.0. \n'
+        'Starting with Ansible Tower 3.0, use the role resource to manage '
+        'access controls. \n'
+        'All commands must specify either a user or a team to operate on.'
+    )
     endpoint = '/permissions/'
     identity = ('name', )
     no_lookup_flag = False

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -75,20 +75,27 @@ class PermissionTests(unittest.TestCase):
             existing_registrations(t)
             t.register_json('/permissions/4/', {}, method='DELETE')
             result = self.res.delete(name='bar', user=3)
+            self.assertTrue(result['changed'])
 
     def test_modify_permission(self):
         with client.test_mode as t:
             existing_registrations(t)
-            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
-            result = self.res.modify(name='bar', user=3, permission_type='admin')
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'},
+                            method='PATCH')
+            result = self.res.modify(name='bar', user=3,
+                                     permission_type='admin')
+            self.assertTrue(result['changed'])
 
     def test_modify_permission_by_pk(self):
         with client.test_mode as t:
             existing_registrations(t)
-            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'},
+                            method='PATCH')
             result = self.res.modify(4, permission_type='admin')
+            self.assertTrue(result['changed'])
 
     def test_list_permissions(self):
         with client.test_mode as t:
             existing_registrations(t)
             result = self.res.list(user=3)
+            self.assertEqual(result['count'], 1)

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -17,12 +17,20 @@ import tower_cli
 from tower_cli.api import client
 from tower_cli.utils import exceptions as exc
 
-from tests.compat import unittest, mock
+from tests.compat import unittest
 
-def common_registrations(t):
+
+def create_registrations(t):
     t.register_json('/users/3/permissions/', {'count': 0, 'results': [],
                     'next': None, 'previous': None}, method='GET')
     t.register_json('/users/3/permissions/', {'id': 4}, method='POST')
+
+
+def existing_registrations(t):
+    t.register_json('/users/3/permissions/', {'count': 1,
+                    'results': [{'id': 4, 'name': 'bar'}],
+                    'next': None, 'previous': None}, method='GET')
+    t.register_json('/permissions/4/', {'id': 4}, method='GET')
 
 
 class PermissionTests(unittest.TestCase):
@@ -34,18 +42,53 @@ class PermissionTests(unittest.TestCase):
 
     def test_create_default_permission_type(self):
         with client.test_mode as t:
-            common_registrations(t)
+            create_registrations(t)
             result = self.res.create(
                 name='bar', user=3, inventory=9
             )
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertDictContainsSubset({'id': 4}, result)
-            
+
     def test_create_write_type(self):
         with client.test_mode as t:
-            common_registrations(t)
+            create_registrations(t)
             result = self.res.create(
                 name='bar', user=3, inventory=9, permission_type='write'
             )
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertDictContainsSubset({'id': 4}, result)
+
+    def test_set_base_url_user(self):
+        self.res.set_base_url(1, None)
+        self.assertEqual(self.res.endpoint, '/users/1/permissions/')
+
+    def test_set_base_url_team(self):
+        self.res.set_base_url(None, 1)
+        self.assertEqual(self.res.endpoint, '/teams/1/permissions/')
+
+    def test_no_user_or_team(self):
+        with self.assertRaises(exc.TowerCLIError):
+            self.res.set_base_url(None, None)
+
+    def test_delete_permission(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {}, method='DELETE')
+            result = self.res.delete(name='bar', user=3)
+
+    def test_modify_permission(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            result = self.res.modify(name='bar', user=3, permission_type='admin')
+
+    def test_modify_permission_by_pk(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            result = self.res.modify(4, permission_type='admin')
+
+    def test_list_permissions(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            result = self.res.list(user=3)

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -1,0 +1,51 @@
+# Copyright 2016, Red Hat
+# Alan Rominger <arominge@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+from tower_cli.utils import exceptions as exc
+
+from tests.compat import unittest, mock
+
+def common_registrations(t):
+    t.register_json('/users/3/permissions/', {'count': 0, 'results': [],
+                    'next': None, 'previous': None}, method='GET')
+    t.register_json('/users/3/permissions/', {'id': 4}, method='POST')
+
+
+class PermissionTests(unittest.TestCase):
+    """A set of tests for checking that the permission feature works
+    correctly.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('permission')
+
+    def test_create_default_permission_type(self):
+        with client.test_mode as t:
+            common_registrations(t)
+            result = self.res.create(
+                name='bar', user=3, inventory=9
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertDictContainsSubset({'id': 4}, result)
+            
+    def test_create_write_type(self):
+        with client.test_mode as t:
+            common_registrations(t)
+            result = self.res.create(
+                name='bar', user=3, inventory=9, permission_type='write'
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertDictContainsSubset({'id': 4}, result)


### PR DESCRIPTION
This adds the ability to create and manage permissions through tower-cli. This has some unique challenges with it - because you can not list permissions globally by a request to `/permissions/`. The ability to do was baked in as an assumption to many common tasks, so this had to be teased out as a special case for the permission class. Instead of doing things globally, you have to specify either a user or a team for every action you take. Because of that, you'll see this code do a switcharoo of the endpoints  before/after the permission primary key is established. That is because of the added complication that you can't subsequently make any requests to and endpoint like `/users/10/permissions/5/`. That is what several tower-cli methods would automatically construct, so special care is given to that case to turn it into `/permissions/5/`.

I haven't yet gone down the full road of testing, because I thought a fast feature sprint might be more efficient in the long run, because this could be tested along side the other new features. The commands that I have used and have found to generally work with consistency with other tower-cli behavior are:

```bash
tower-cli permission create --name="from_CLI" --user=18 --inventory=19 -v
tower-cli permission modify --name="from_CLI" --user=18 --description="edit from cli" -v
tower-cli permission delete --name="from_CLI" --user=bio_citizen -v
tower-cli permission list --user=bio_citizen
tower-cli permission get --name=righttoclick --user=bio_citizen
```

Fixes #51 