### PR TITLE
Accept file or direct variables for inventory, host, group

### DIFF
--- a/docs/examples/fake_data_creator.sh
+++ b/docs/examples/fake_data_creator.sh
@@ -106,17 +106,17 @@ tower-cli credential create --name=user2 --username=user2 --password=pass1 --tea
 
 echo "Tower-CLI DATA FAKER: creating inventories and groups"
 # Basic localhost examples
-tower-cli inventory create --name=localhost --description="local machine" --organization=Default --variables="variables.yml"
-tower-cli host create --name="127.0.0.1" --description="the host in localhost" --inventory="localhost" --variables="variables.yml"
+tower-cli inventory create --name=localhost --description="local machine" --organization=Default --variables="@variables.yml"
+tower-cli host create --name="127.0.0.1" --description="the host in localhost" --inventory="localhost" --variables="@variables.yml"
 # Corporate example uses localhost with special vars for testing
-tower-cli inventory create --name=Production --description="Production Machines" --organization="Hyrule Ventures" --variables="variables.yml"
+tower-cli inventory create --name=Production --description="Production Machines" --organization="Hyrule Ventures" --variables="@variables.yml"
 tower-cli group create --name=EC2 --credential="AWS creds" --source=ec2 --description="EC2 hosts" --inventory=Production
 tower-cli group create --name=RAX --credential="RAX creds" --source=rax --description="RAX hosts" --inventory=Production
 # EC2vars demonstrates the use of advanced source variables
 tower-cli group create --name=EC2vars --credential="AWS creds" --source=ec2 --description="EC2 hosts" --inventory=Production --source-regions="us-east-1" --overwrite=true --overwrite-vars=false --source-vars="foo: bar"
 # Another example
-tower-cli inventory create --name="Testing" --description="Test Machines" --organization="Bio Inc" --variables="variables.yml"
-tower-cli group create --name=web --source=manual --inventory=Testing --variables="variables.yml"
+tower-cli inventory create --name="Testing" --description="Test Machines" --organization="Bio Inc" --variables="@variables.yml"
+tower-cli group create --name=web --source=manual --inventory=Testing --variables="@variables.yml"
 tower-cli host create --name="10.42.0.6" --inventory=Testing
 tower-cli host create --name="10.42.0.7" --inventory=Testing
 tower-cli host create --name="10.42.0.8" --inventory=Testing
@@ -124,10 +124,10 @@ tower-cli host create --name="10.42.0.9" --inventory=Testing
 tower-cli host create --name="10.42.0.10" --inventory=Testing
 # Another inventory, but with recursive structure
 # these include databases and web servers, with hosts in the web server group
-tower-cli inventory create --name=QA --description="QA Machines" --organization=Default --variables="variables.yml"
-tower-cli group create --name="databases" --source=manual --inventory=QA --variables="variables.yml"
+tower-cli inventory create --name=QA --description="QA Machines" --organization=Default --variables="@variables.yml"
+tower-cli group create --name="databases" --source=manual --inventory=QA --variables="@variables.yml"
 # Setting up the web servers, associate hosts with the group
-tower-cli group create --name="web servers" --source=manual --inventory=QA --variables="variables.yml"
+tower-cli group create --name="web servers" --source=manual --inventory=QA --variables="@variables.yml"
 tower-cli host create --name="server.example1.com" --inventory=QA
 tower-cli host associate --host="server.example1.com" --group="web servers"
 tower-cli host create --name="server.example2.com" --inventory=QA

--- a/docs/examples/teardown_script.sh
+++ b/docs/examples/teardown_script.sh
@@ -43,10 +43,10 @@ tower-cli project delete --name="Ansible Examples"
 echo "Tower-CLI DATA FAKER: deleting orgs and teams"
 # Teams do not automatically go away when their organization is deleted
 # so we must delete them all
-tower-cli team delete --name Ops
-tower-cli team delete --name QA
-tower-cli team delete --name Dev
-tower-cli team delete --name Engineering
-tower-cli team delete --name "Tech Services"
+tower-cli team delete --name Ops --organization=Default
+tower-cli team delete --name QA --organization=Default
+tower-cli team delete --name Dev --organization=Default
+tower-cli team delete --name Engineering --organization="Bio Inc"
+tower-cli team delete --name "Tech Services" --organization="Bio Inc"
 tower-cli organization delete --name="Hyrule Ventures"
 tower-cli organization delete --name="Bio Inc"

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -227,7 +227,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                             else None,
                             help=field.help,
                             type=field.type,
-                            show_default=field.show_default
+                            show_default=field.show_default,
+                            cls=field.cls
                         )(new_method)
 
                 # Make a click Command instance using this method

--- a/lib/tower_cli/models/fields.py
+++ b/lib/tower_cli/models/fields.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import six
+from click import Option
+from tower_cli.utils.types import VariableOption
 
 
 _field_counter = 0
@@ -26,7 +28,8 @@ class Field(object):
     def __init__(self, key=None, type=six.text_type, default=None,
                  display=True, filterable=True, help_text=None,
                  is_option=True, password=False, read_only=False,
-                 required=True, show_default=False, unique=False):
+                 required=True, show_default=False, unique=False,
+                 yaml_vars=False):
         # Init the name to blank.
         # What's going on here: This is set by the ResourceMeta metaclass
         # when the **resource** is instantiated.
@@ -47,6 +50,10 @@ class Field(object):
         self.required = required
         self.show_default = show_default
         self.unique = unique
+        if yaml_vars:
+            self.cls = VariableOption
+        else:
+            self.cls = Option
 
         # If this is a password, display is always off.
         if self.password:

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -18,6 +18,7 @@ import click
 from tower_cli import get_resource, models, resources
 from tower_cli.api import client
 from tower_cli.utils import exceptions as exc, types
+from tower_cli.utils.types import VariableOption
 
 INVENTORY_SOURCES = ['manual', 'ec2', 'rax', 'vmware',
                      'gce', 'azure', 'openstack']
@@ -31,8 +32,7 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
-    variables = models.Field(type=types.Variable(), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)
 
     # Basic options for the source
     @click.option('--credential', type=types.Related('credential'),
@@ -44,7 +44,7 @@ class Resource(models.Resource):
     @click.option('--source-regions', help='Regions for your cloud provider.')
     # Options may not be valid for certain types of cloud servers
     @click.option('--source-vars', help='Override variables found on source '
-                  'with variables defined in this field.')
+                  'with variables defined in this field.', cls=VariableOption)
     @click.option('--overwrite', type=bool,
                   help='Delete child groups and hosts not found in source.')
     @click.option('--overwrite-vars', type=bool,
@@ -107,7 +107,7 @@ class Resource(models.Resource):
     @click.option('--source-regions', help='Regions for your cloud provider.')
     # Options may not be valid for certain types of cloud servers
     @click.option('--source-vars', help='Override variables found on source '
-                  'with variables defined in this field.')
+                  'with variables defined in this field.', cls=VariableOption)
     @click.option('--overwrite', type=bool,
                   help='Delete child groups and hosts not found in source.')
     @click.option('--overwrite-vars', type=bool,

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -31,7 +31,7 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
-    variables = models.Field(type=types.File('r'), required=False,
+    variables = models.Field(type=types.Variable(), required=False,
                              display=False)
 
     # Basic options for the source

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -28,7 +28,7 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
     enabled = models.Field(type=bool, required=False)
-    variables = models.Field(type=types.File('r'), required=False,
+    variables = models.Field(type=types.Variable(), required=False,
                              display=False)
 
     @resources.command(use_fields_as_options=False)

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -28,8 +28,7 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
     enabled = models.Field(type=bool, required=False)
-    variables = models.Field(type=types.Variable(), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)
 
     @resources.command(use_fields_as_options=False)
     @click.option('--host', type=types.Related('host'))

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -25,5 +25,4 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
-    variables = models.Field(type=types.Variable(), required=False,
-                             display=False)
+    variables = models.Field(required=False, display=False, yaml_vars=True)

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -25,5 +25,5 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
-    variables = models.Field(type=models.File('r'), required=False,
+    variables = models.Field(type=types.Variable(), required=False,
                              display=False)

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -36,7 +36,8 @@ class Resource(models.MonitorableResource):
     )
     source_regions = models.Field(required=False, display=False)
     # Variables not shared by all cloud providers
-    source_vars = models.Field(required=False, display=False)
+    source_vars = models.Field(
+        type=types.Variable(), required=False, display=False)
     # Boolean variables
     overwrite = models.Field(type=bool, required=False, display=False)
     overwrite_vars = models.Field(type=bool, required=False, display=False)

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -36,8 +36,7 @@ class Resource(models.MonitorableResource):
     )
     source_regions = models.Field(required=False, display=False)
     # Variables not shared by all cloud providers
-    source_vars = models.Field(
-        type=types.Variable(), required=False, display=False)
+    source_vars = models.Field(required=False, display=False, yaml_vars=True)
     # Boolean variables
     overwrite = models.Field(type=bool, required=False, display=False)
     overwrite_vars = models.Field(type=bool, required=False, display=False)

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -119,10 +119,10 @@ def process_extra_vars(extra_vars_list, force_json=True):
             opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
         # Rolling YAML-based string combination
         if any(line.startswith("#") for line in extra_vars_opt.split('\n')):
-            extra_vars_yaml += extra_vars_opt + "\n"
+            extra_vars_yaml += extra_vars_opt.strip("\n") + "\n"
         elif extra_vars_opt != "":
             extra_vars_yaml += yaml.dump(
-                opt_dict, default_flow_style=False) + "\n"
+                opt_dict, default_flow_style=False).strip("\n") + "\n"
         # Combine dictionary with cumulative dictionary
         extra_vars.update(opt_dict)
 

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -20,7 +20,7 @@ import re
 import click
 
 import tower_cli
-from tower_cli.utils import debug, exceptions as exc
+from tower_cli.utils import debug, exceptions as exc, parser
 from tower_cli.utils.compat import OrderedDict
 
 
@@ -118,3 +118,16 @@ class Related(click.types.ParamType):
 
     def get_metavar(self, param):
         return self.resource_name.upper()
+
+
+class Variable(click.types.ParamType):
+    """Ansible varibles specified as a file or YAML/JSON text."""
+    name = 'variable'
+
+    def convert(self, value, param, ctx):
+        """Return the appropriate variable string."""
+        if value is None:
+            return None
+
+        # combine sources of extra variables
+        return parser.process_extra_vars([value], force_json=False)


### PR DESCRIPTION
This will allow the `--variables` option on inventory, host, group (and `--source-vars` on group) to retrieve data from a file if it starts with an "@". This PR is mainly doing routing work through the click library capabilities combined with the specific tower-cli architecture. Variables are implemented as a custom type. I wanted to allow multiple flags (like in job and job template), but I couldn't quite work through the technical challenges of doing that. This is still a much more elegant approach than what I have been using, and it shows a minimal footprint on the code for the resources (which is a part of the tower-cli design philosophy).

I need to check back later and audit what's showing for help text, as well as do more testing, so putting the in_progress label on this for now.

Fixes #104 