### PR TITLE
Standard out streaming feature

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -798,7 +798,7 @@ class MonitorableResource(ResourceMethods):
     @click.option('--stdout', is_flag=True,
                   help='Prints stdout on a rolling basis.')
     def monitor(self, pk, min_interval=1, max_interval=30,
-                timeout=None, stdout=True, outfile=sys.stdout, **kwargs):
+                timeout=None, stdout=False, outfile=sys.stdout, **kwargs):
         """Monitor a running job.
 
         Blocks further input until the job completes (whether successfully or
@@ -815,7 +815,7 @@ class MonitorableResource(ResourceMethods):
         start_line = 0
         end_line = STDOUT_STEP
         content = ""
-        stdout_url = '/jobs/%d/stdout/' % pk
+        stdout_url = '%s%d/stdout/' % (self.endpoint, pk)
         payload = {'format': 'json', 'content_encoding': 'base64',
                    'content_format': 'ansi',
                    'start_line': start_line, 'end_line': end_line}

--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -74,6 +74,8 @@ class Resource(models.ExeResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `monitor` on the newly '
                        'launched command rather than exiting with a success.')
+    @click.option('--stdout', is_flag=True,
+                  help='Stream the standard out from the Tower server.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this attempt'
                        ' will time out after the given number of seconds. '
@@ -81,7 +83,8 @@ class Resource(models.ExeResource):
     @click.option('--become', required=False, is_flag=True,
                   help='If used, privledge escalation will be enabled for '
                        'this command.')
-    def launch(self, monitor=False, timeout=None, become=False, **kwargs):
+    def launch(self, monitor=False, stdout=False, timeout=None,
+               become=False, **kwargs):
         """Launch a new ad-hoc command.
 
         Runs a user-defined command from Ansible Tower, immediately starts it,
@@ -111,7 +114,7 @@ class Resource(models.ExeResource):
         # If we were told to monitor the command once it started, then call
         # monitor from here.
         if monitor:
-            return self.monitor(command_id, timeout=timeout)
+            return self.monitor(command_id, timeout=timeout, stdout=stdout)
 
         # Return the command ID and other response data
         answer = OrderedDict((

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -177,3 +177,13 @@ class Resource(models.ExeResource):
             return self.monitor(job_id, timeout=timeout, stdout=stdout)
 
         return result
+
+    @resources.command
+    def stdout(self, pk=None, **kwargs):
+        """Print out the plaintext standard out of the job to the command
+        line. Note that failed and incomplete jobs will not succeed in this
+        request.
+        """
+        stdout_data = client.get('/jobs/%d/stdout/?format=txt' % pk)
+        click.echo('\n' + str(stdout_data._content) + '\n')
+        return self.get(pk, **kwargs)

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -51,8 +51,7 @@ class Resource(models.ExeResource):
                   help='If sent, immediately calls `job monitor` on the newly '
                        'launched job rather than exiting with a success.')
     @click.option('--stdout', is_flag=True,
-                  help='Stream the standard out from the Tower server '
-                       'try it, it\'s a blast!')
+                  help='Stream the standard out from the Tower server.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -50,6 +50,9 @@ class Resource(models.ExeResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `job monitor` on the newly '
                        'launched job rather than exiting with a success.')
+    @click.option('--stdout', is_flag=True,
+                  help='Stream the standard out from the Tower server '
+                       'try it, it\'s a blast!')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '
@@ -62,7 +65,7 @@ class Resource(models.ExeResource):
     @click.option('--tags', required=False,
                   help='Specify tagged actions in the playbook to run.')
     def launch(self, job_template=None, tags=None, monitor=False, timeout=None,
-               no_input=True, extra_vars=None, **kwargs):
+               no_input=True, extra_vars=None, stdout=False, **kwargs):
         """Launch a new job based on a job template.
 
         Creates a new job in Ansible Tower, immediately starts it, and
@@ -172,6 +175,6 @@ class Resource(models.ExeResource):
         # If we were told to monitor the job once it started, then call
         # monitor from here.
         if monitor:
-            return self.monitor(job_id, timeout=timeout)
+            return self.monitor(job_id, timeout=timeout, stdout=stdout)
 
         return result

--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -127,7 +127,7 @@ class LaunchTests(unittest.TestCase):
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.launch(inventory=1, machine_credential=2,
                                 module_args="echo 'hi'", monitor=True)
-                monitor.assert_called_once_with(42, timeout=None)
+                monitor.assert_called_once_with(42, timeout=None, stdout=False)
 
 
 class StatusTests(unittest.TestCase):

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -81,6 +81,16 @@ def jt_vars_registration(t, extra_vars):
                     method='POST')
 
 
+def monitor_registration(t):
+    """ Endpoints common to any monitoring task are registered here. """
+
+    # Do standard registration first
+    standard_registration(t)
+
+    # Endpoint used for standard out streaming
+    t.register_json('/jobs/42/stdout/', {'content': ''})
+
+
 class LaunchTests(unittest.TestCase):
     """A set of tests for ensuring that the job resource's launch command
     works in the way we expect.
@@ -135,10 +145,10 @@ class LaunchTests(unittest.TestCase):
         any invocation-time input, and that monitor is called if requested.
         """
         with client.test_mode as t:
-            standard_registration(t)
+            monitor_registration(t)
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.launch(1, monitor=True)
-                monitor.assert_called_once_with(42, timeout=None)
+                monitor.assert_called_once_with(42, timeout=None, stdout=False)
 
     def test_extra_vars_at_runtime(self):
         """Establish that if we should be asking for extra variables at


### PR DESCRIPTION
This replaces Pull #105.

--
Streaming standard out:

    tower-cli job launch --job-template=74 --monitor --stdout

Getting the standard out from a job that has already ran:

    tower-cli job stdout 572

This functionality is focused very heavily on a human user running tower-cli from the command line. It also gets us somewhat closer to Ansible core parity, because it allows you to kick off a job and see the standard out stream back to you as it goes. Of course, it's a little more complicated with Tower because it will sit in the queue before it can start, and other factors like that. The testing of this so-far has consisted of trial and error getting the output to format exactly like what we want. However, if the `--stdout` flag is not given, there should not be any possibility of negatively affecting other features of tower-cli.

The unit test situation is going to be a little complicated, so I haven't even attempted to write tests just yet. Since all of the streaming exists inside of a loop in the monitor method, it is very difficult to try all of the permutations in the job unit tests without setting up a vast universe of mock. We will need some feedback on that, so I'm marking this "in progress".

Fixes #74 