### PR TITLE
Script feature added

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+2.4.0 (2015-12-xx)
+------------------
+- Added inventory script sub-command
+
 2.3.1 (2015-12-10)
 ------------------
 
@@ -8,6 +12,7 @@ Release History
 - Changed extra_vars behavior to be more compliant by re-parsing vars,
   even when only one source exists
 - Fixed group modify bug, avoid sending unwanted fields in modify requests
+- Added ability to declare user organization admin
 
 2.3.0 (2015-10-20)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ A few potential uses include:
    Bamboo, etc)
 -  Checking on job statuses
 -  Rapidly creating objects like organizations, users, teams, and more
+-  Pull in `dynamic inventory scripts </docs/inventory_script.rst>`__
+   from Ansible Tower .
 
 Installation
 ------------

--- a/docs/inventory_script.rst
+++ b/docs/inventory_script.rst
@@ -1,8 +1,9 @@
 Inventory Script Subcommand
 ===========================
 
-The inventory script subcommand returns the output of dynamic inventory
-scripts in JSON format by default. It can be invoked by either the primary
+The tower-cli inventory script subcommand returns information about an
+inventory in JSON format, consistent with Ansible standards for dynamic
+inventory. It can be invoked by either the primary
 key or another set of parameters that uniquely specifies the inventory.
 
 For example, if the inventory was named ``QA_machines`` and had an primary
@@ -20,22 +21,32 @@ or
 
 These commands will return text in JSON format.
 
-Example Usage
--------------
+Usage
+-----
 
-As a part of bash scripting (or some other automated workflow), this
-command can be leveraged to feed dynamic inventory into Ansible locally
+This command can be leveraged to feed dynamic inventory into Ansible locally
 from Ansible Tower.
 
-Tower-cli will can act as a stand-in for a script that dynamically defines
-inventory. For example, consider the following file
-named ```tower-inventory.sh``.
+This can be implemented by feeding the command's output into Ansible through
+the ```-i``` flag. However, an executable file is needed to act as a wrapper
+in this usage. One possible option to do this is described below.
+
+Manual Bash Wrapper Setup
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a file named ```tower-inventory.sh`` with the following contents.
 
 .. code:: bash
 
     #!/bin/bash
 
-    tower-cli inventory script $TOWER_INVENTORY_ID --hostvars=1
+    tower-cli inventory script $TOWER_INVENTORY_ID
+
+Save the file, and change its permissions to be executable.
+
+.. code:: bash
+
+    chmod +x tower-inventory.sh
 
 While in the same directory, the following command will list the hosts via
 Ansible in its command-line usage.

--- a/docs/inventory_script.rst
+++ b/docs/inventory_script.rst
@@ -1,0 +1,43 @@
+Inventory Script Subcommand
+===========================
+
+The inventory script subcommand returns the output of dynamic inventory
+scripts in JSON format by default. It can be invoked by either the primary
+key or another set of parameters that uniquely specifies the inventory.
+
+For example, if the inventory was named "QA_machines" and had an primary
+key of 12, either of the following commands would be valid:
+
+.. code:: bash
+
+    $ tower-cli inventory script --name="QA_machines"
+
+    $ tower-cli inventory script 12
+
+These commands will return text in JSON format.
+
+Example Usage
+-------------
+
+As a part of bash scripting (or some other automated workflow), this
+command can be leveraged to feed dynamic inventory into Ansible locally
+from Ansible Tower.
+
+Tower-cli will can act as a stand-in for a script that dynamically defines
+inventory. For example, consider the following file named `tower-inventory.sh`.
+
+.. code:: bash
+
+    #!/bin/bash
+
+    tower-cli inventory script $TOWER_INVENTORY_ID --hostvars=1
+
+While in the same directory, the following command will list the hosts via
+Ansible in its command-line usage.
+
+.. code:: bash
+
+    TOWER_INVENTORY_ID=12 ansible -i tower-inventory.sh all --list-hosts
+
+Assuming the inventory pk is 12, this will give a list of hosts in that
+inventory.

--- a/docs/inventory_script.rst
+++ b/docs/inventory_script.rst
@@ -5,12 +5,16 @@ The inventory script subcommand returns the output of dynamic inventory
 scripts in JSON format by default. It can be invoked by either the primary
 key or another set of parameters that uniquely specifies the inventory.
 
-For example, if the inventory was named "QA_machines" and had an primary
-key of 12, either of the following commands would be valid:
+For example, if the inventory was named ``QA_machines`` and had an primary
+key of ``12``, either of the following commands would be valid:
 
 .. code:: bash
 
     $ tower-cli inventory script --name="QA_machines"
+
+or
+
+.. code:: bash
 
     $ tower-cli inventory script 12
 
@@ -24,7 +28,8 @@ command can be leveraged to feed dynamic inventory into Ansible locally
 from Ansible Tower.
 
 Tower-cli will can act as a stand-in for a script that dynamically defines
-inventory. For example, consider the following file named `tower-inventory.sh`.
+inventory. For example, consider the following file
+named ```tower-inventory.sh``.
 
 .. code:: bash
 

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -35,14 +35,16 @@ class Resource(models.Resource):
     @click.option('--hostvars', required=False, type=int,
                   help='Set to 1 to include host variables')
     def script(self, pk=None, format='json', **kwargs):
-        """Return the script output for an inventory."""
+        """Return Ansible dynamic inventory script output."""
 
         # set runtime value of format setting
         settings.format = format
 
         # pull out dictionary of values to pass in request
+        # also necessary in order to remove the script-specific parameters
+        # from the dictionary used for the inventory lookup
         payload = dict(
-            (k, kwargs[k]) for k in ['hostvars'] if k in kwargs
+            (k, kwargs.pop(k)) for k in ['hostvars'] if k in kwargs
         )
 
         # if primary key not given, look up via the standard get routine

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tower_cli import models
-from tower_cli.utils import types
+import click
+
+from tower_cli import models, resources
+from tower_cli.utils import types, debug
+from tower_cli.api import client
+from tower_cli.conf import settings
 
 
 class Resource(models.Resource):
@@ -26,3 +30,30 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
     variables = models.Field(required=False, display=False, yaml_vars=True)
+
+    @resources.command
+    @click.option('--hostvars', required=False, type=int,
+                  help='Set to 1 to include host variables')
+    def script(self, pk=None, format='json', **kwargs):
+        """Return the script output for an inventory."""
+
+        # set runtime value of format setting
+        settings.format = format
+
+        # pull out dictionary of values to pass in request
+        payload = dict(
+            (k, kwargs[k]) for k in ['hostvars'] if k in kwargs
+        )
+
+        # if primary key not given, look up via the standard get routine
+        if not pk:
+            get_resp = self.get(**kwargs)
+            pk = get_resp['id']
+
+        # make the request to /inventories/pk/script/
+        debug.log('Getting script for inventory.', header='details')
+        script_url = '%s%d/script/' % (self.endpoint, pk)
+        r = client.get(script_url, params=payload)
+        resp = r.json()
+
+        return resp

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
-
 from tower_cli import models, resources
 from tower_cli.utils import types, debug
 from tower_cli.api import client
@@ -32,13 +30,14 @@ class Resource(models.Resource):
     variables = models.Field(required=False, display=False, yaml_vars=True)
 
     @resources.command
-    @click.option('--hostvars', required=False, type=int,
-                  help='Set to 1 to include host variables')
-    def script(self, pk=None, format='json', **kwargs):
+    def script(self, pk=None, format=None, **kwargs):
         """Return Ansible dynamic inventory script output."""
 
         # set runtime value of format setting
-        settings.format = format
+        settings.format = 'json'
+
+        # hostvars necessary to get usable script
+        kwargs['hostvars'] = 1
 
         # pull out dictionary of values to pass in request
         # also necessary in order to remove the script-specific parameters

--- a/tests/test_resources_inventory_script.py
+++ b/tests/test_resources_inventory_script.py
@@ -1,0 +1,50 @@
+# Copyright 2015, Red Hat, Inc.
+# Alan Rominger <arominger@ansible.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+
+from tests.compat import unittest
+
+
+class UpdateTests(unittest.TestCase):
+    """A set of tests for inventory script retrevial
+    tower-cli inventory script inventory_id
+    """
+    def setUp(self):
+        self.inventory = tower_cli.get_resource('inventory')
+
+    def test_lookup_pk(self):
+        """Test retrevial of an inventory script output by its pk
+        """
+        result_dict = {'all': {'hosts': []}}
+        with client.test_mode as t:
+            t.register_json('/inventories/12/script/',
+                            result_dict, method='GET')
+            result = self.inventory.script(pk=12)
+            assert result == result_dict
+
+    def test_lookup_name(self):
+        """Test retrevial of an inventory script output by its name
+        """
+        result_dict = {'all': {'hosts': []}}
+        with client.test_mode as t:
+            t.register_json('/inventories/12/script/',
+                            result_dict, method='GET')
+            t.register_json(
+                '/inventories/', {'count': 1, 'results': [{'id': 12}]},
+                method='GET')
+            result = self.inventory.script(name='foobar_inventory')
+            assert result == result_dict


### PR DESCRIPTION
Putting into feature set for release_2.4. This replaces Pull #95.

--
This adds the `script` subcommand to the inventory resource, it is used in the following way:

> $ tower-cli inventory script 12 --hostvars=1

Unlike other commands, the default format is json, which is done because most foreseeable uses will use this type of output, and the "human" output does not look very polished.

Packaged along with this, we also have tests for 100% coverage of inventory.py, along with some documentation.

I would have preferred to have hostvars default set 1, but there was no simple way to accomplish this while still preserving the user's ability to turn it off (no way which also didn't involve more tests). Thus, I'm going with this as the most elegant solution that we can pull off. If there are any more options to be added, I would love to add them, but the OPTIONS didn't give anything useful and no testing seemed fruitful. The tower-cli command still has many other options which are either appended as baggage in lower-level wrappers, or for the ability to look up an inventory by name.

Fixes #89 