### PR TITLE
Short flag feature

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 2.4.0 (2015-12-xx)
 ------------------
 - Added inventory script sub-command
+- Added optional short flags for common fields
 
 2.3.1 (2015-12-10)
 ------------------

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -221,6 +221,19 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                         if field.key:
                             args.insert(0, field.key)
 
+                        # short name aliases for common flags
+                        short_fields = {
+                            'name': 'n',
+                            'description': 'd',
+                            'become': 'b',
+                            'extra_vars': 'e',
+                            'tags': 't',
+                            'inventory': 'i',
+                            'extra_vars': 'e'
+                        }
+                        if field.name in short_fields:
+                            args.append('-'+short_fields[field.name])
+
                         # Apply the option to the method.
                         click.option(
                             *args,

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -37,6 +37,7 @@ class Resource(models.ExeResource):
     endpoint = '/jobs/'
 
     job_template = models.Field(
+        key='-J',
         type=types.Related('job_template'), required=False, display=True
     )
     job_explanation = models.Field(required=False, display=False)
@@ -58,10 +59,10 @@ class Resource(models.ExeResource):
                        'Does nothing if --monitor is not sent.')
     @click.option('--no-input', is_flag=True, default=False,
                   help='Suppress any requests for input.')
-    @click.option('--extra-vars', required=False, multiple=True,
+    @click.option('-e', '--extra-vars', required=False, multiple=True,
                   help='yaml format text that contains extra variables '
                        'to pass on. Use @ to get these from a file.')
-    @click.option('--tags', required=False,
+    @click.option('-t', '--tags', required=False,
                   help='Specify tagged actions in the playbook to run.')
     def launch(self, job_template=None, tags=None, monitor=False, timeout=None,
                no_input=True, extra_vars=None, stdout=False, **kwargs):

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -43,7 +43,7 @@ class Resource(models.Resource):
     cloud_credential = models.Field(type=types.Related('credential'),
                                     required=False, display=False)
     forks = models.Field(type=int, required=False, display=False)
-    limit = models.Field(required=False, display=False)
+    limit = models.Field(key='-l', required=False, display=False)
     verbosity = models.Field(
         display=False,
         type=types.MappedChoice([
@@ -53,7 +53,7 @@ class Resource(models.Resource):
         ]),
         required=False,
     )
-    job_tags = models.Field(required=False, display=False)
+    job_tags = models.Field(key='-t', required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
     extra_vars = models.Field(required=False, display=False)
     ask_variables_on_launch = models.Field(

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -176,7 +176,7 @@ class SubcommandTests(unittest.TestCase):
         # Ensure that this command has an option corresponding to the
         # "name" unique field.
         self.assertEqual(list_command.params[0].name, 'name')
-        self.assertEqual(list_command.params[0].opts, ['--name'])
+        self.assertIn('--name', list_command.params[0].opts)
 
     def test_get_command_error(self):
         """Establish that if `get_command` is called against a command that


### PR DESCRIPTION
This allows users to use a quick `-n` flag instead of using `--name`, for example. Because most of these fields are used in multiple resources, I opted for addressing this problem closer to the source with a dictionary of shortened command right before the loop which applies the options to a command. There are also a few special cases that I felt were appropriate.

More description of the problem can be found in the linked issue.

Fixes #102 