### PR TITLE
Use the variables field type to consolidate code

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -43,9 +43,10 @@ class Resource(models.ExeResource):
     created = models.Field(required=False, display=True)
     status = models.Field(required=False, display=True)
     elapsed = models.Field(required=False, display=True)
+    extra_vars = models.Field(required=False, display=False, yaml_vars=True)
 
     @resources.command(
-        use_fields_as_options=('job_template', 'job_explanation')
+        use_fields_as_options=('job_template', 'job_explanation', 'extra_vars')
     )
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `job monitor` on the newly '
@@ -56,9 +57,6 @@ class Resource(models.ExeResource):
                        'Does nothing if --monitor is not sent.')
     @click.option('--no-input', is_flag=True, default=False,
                   help='Suppress any requests for input.')
-    @click.option('--extra-vars', required=False, multiple=True,
-                  help='yaml format text that contains extra variables '
-                       'to pass on. Use @ to get these from a file.')
     @click.option('--tags', required=False,
                   help='Specify tagged actions in the playbook to run.')
     def launch(self, job_template=None, tags=None, monitor=False, timeout=None,
@@ -93,7 +91,7 @@ class Resource(models.ExeResource):
 
         # Add the runtime extra_vars to this list
         if extra_vars:
-            extra_vars_list += list(extra_vars)  # accept tuples
+            extra_vars_list += [extra_vars]
 
         # If the job template requires prompting for extra variables,
         # do so (unless --no-input is set).

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -19,7 +19,6 @@ import click
 
 from tower_cli import models
 from tower_cli.utils import types
-from tower_cli.utils import parser
 
 
 class Resource(models.Resource):
@@ -55,48 +54,8 @@ class Resource(models.Resource):
     )
     job_tags = models.Field(required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
-    extra_vars = models.Field(required=False, display=False)
+    extra_vars = models.Field(required=False, display=False, yaml_vars=True)
     ask_variables_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for extra_vars on launch.')
     become_enabled = models.Field(type=bool, required=False, display=False)
-
-    @click.option('--extra-vars', required=False, multiple=True,
-                  help='Extra variables used by Ansible in YAML or key=value '
-                       'format. Use @ to get YAML from a file.')
-    def create(self, fail_on_found=False, force_on_exists=False,
-               extra_vars=None, **kwargs):
-        """Create a job template.
-        You may include multiple --extra-vars flags in order to combine
-        different sources of extra variables. Start this
-        with @ in order to indicate a filename."""
-        if extra_vars:
-            # combine sources of extra variables, if given
-            kwargs['extra_vars'] = parser.process_extra_vars(
-                extra_vars, force_json=False
-            )
-        # Provide a default value for job_type, but only in creation of JT
-        if not kwargs.get('job_type', False):
-            kwargs['job_type'] = 'run'
-        return super(Resource, self).create(
-            fail_on_found=fail_on_found, force_on_exists=force_on_exists,
-            **kwargs
-        )
-
-    @click.option('--extra-vars', required=False, multiple=True,
-                  help='Extra variables used by Ansible in YAML or key=value '
-                       'format. Use @ to get YAML from a file.')
-    def modify(self, pk=None, create_on_missing=False,
-               extra_vars=None, **kwargs):
-        """Modify a job template.
-        You may include multiple --extra-vars flags in order to combine
-        different sources of extra variables. Start this
-        with @ in order to indicate a filename."""
-        if extra_vars:
-            # combine sources of extra variables, if given
-            kwargs['extra_vars'] = parser.process_extra_vars(
-                extra_vars, force_json=False
-            )
-        return super(Resource, self).modify(
-            pk=pk, create_on_missing=create_on_missing, **kwargs
-        )


### PR DESCRIPTION
There was a lot of extra legwork being done in the job template that we can now remove with use of the variable type field. This PR removes all those extra methods on job template that we can really do without.