### PR TITLE
Test and fix case where JT extra_vars are dictionary

### DIFF
--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -19,6 +19,7 @@ import json
 import ast
 import shlex
 import sys
+from tower_cli.utils.data_structures import OrderedDict
 
 from tower_cli.utils import exceptions as exc, debug
 
@@ -109,20 +110,25 @@ def process_extra_vars(extra_vars_list, force_json=True):
     extra_vars_yaml = ""
     for extra_vars_opt in extra_vars_list:
         # Load file content if necessary
-        if extra_vars_opt.startswith("@"):
-            with open(extra_vars_opt[1:], 'r') as f:
-                extra_vars_opt = f.read()
-            # Convert text markup to a dictionary conservatively
-            opt_dict = string_to_dict(extra_vars_opt, allow_kv=False)
+        if type(extra_vars_opt) is dict or type(extra_vars_opt) is OrderedDict:
+            opt_dict = extra_vars_opt
         else:
-            # Convert text markup to a dictionary liberally
-            opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
-        # Rolling YAML-based string combination
-        if any(line.startswith("#") for line in extra_vars_opt.split('\n')):
-            extra_vars_yaml += extra_vars_opt + "\n"
-        elif extra_vars_opt != "":
-            extra_vars_yaml += yaml.dump(
-                opt_dict, default_flow_style=False) + "\n"
+            if extra_vars_opt.startswith("@"):
+                with open(extra_vars_opt[1:], 'r') as f:
+                    extra_vars_opt = f.read()
+                # Convert text markup to a dictionary conservatively
+                opt_dict = string_to_dict(extra_vars_opt, allow_kv=False)
+            else:
+                # Convert text markup to a dictionary liberally
+                opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
+            # Rolling YAML-based string combination
+            if any(
+                line.startswith("#") for line in extra_vars_opt.split('\n')
+            ):
+                extra_vars_yaml += extra_vars_opt + "\n"
+            elif extra_vars_opt != "":
+                extra_vars_yaml += yaml.dump(
+                    opt_dict, default_flow_style=False) + "\n"
         # Combine dictionary with cumulative dictionary
         extra_vars.update(opt_dict)
 


### PR DESCRIPTION
I have not confirmed that this is, indeed, the issue that was observed, but it looks like the logical culprit. So I want to go ahead and push this PR to get the low-hanging fruit.

# Test Behavior

This is test-driven development. My hypothesis after seeing the issue is that older versions of Tower do not string-ify the extra_vars field on Job Templates every time. So I went ahead and broadened the structure of an existing test to launch a job, creating mayhem by giving it a dictionary for the field.

This caused the current version of the code to fail. It was also nice that it failed with the same type of error as was reported in the issue (although, again, I'm not completely sure this is the same thing).

# Description of Code Change

We loop through a list of sources of extra_vars (in reverse order of variable precedence) and squish them all together in a single dictionary. This is most relevant if the Tower version is < 2.4, in which case we are combining the Job Template variables.

So, as we're going through item-by-item, I added a clause that checks if it looks like a dictionary. If it is, then I pass it on through as-is.

Fixes #124 