### PR TITLE
Permission lookup bug fix in release branch

### DIFF
--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -53,7 +53,10 @@ class Resource(models.Resource):
 
     def get_base_url(self, user, team):
         """Return a string that specifies the endpoint to use"""
-        if not user and not team:
+        if 'user' in self.endpoint or 'team' in self.endpoint:
+            # This function has already been ran, so take no action
+            return self.endpoint
+        elif not user and not team:
             raise exc.TowerCLIError('Specify either a user or a team.')
         elif user:
             return '/users/%d/permissions/' % user
@@ -64,7 +67,7 @@ class Resource(models.Resource):
         """Return the pk with a search method specific to permissions."""
         if not pk:
             self.endpoint = self.get_base_url(user, team)
-            debug.log('Checking for an existing record.', header='details')
+            debug.log('Checking for existing permission.', header='details')
             existing_data = self._lookup(
                 fail_on_found=False, fail_on_missing=True,
                 include_debug_header=False, **kwargs)

--- a/lib/tower_cli/resources/permission.py
+++ b/lib/tower_cli/resources/permission.py
@@ -1,5 +1,5 @@
-# Copyright 2015, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Copyright 2016, Red Hat
+# Alan Rominger <arominge@redhat.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -75,20 +75,27 @@ class PermissionTests(unittest.TestCase):
             existing_registrations(t)
             t.register_json('/permissions/4/', {}, method='DELETE')
             result = self.res.delete(name='bar', user=3)
+            self.assertTrue(result['changed'])
 
     def test_modify_permission(self):
         with client.test_mode as t:
             existing_registrations(t)
-            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
-            result = self.res.modify(name='bar', user=3, permission_type='admin')
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'},
+                            method='PATCH')
+            result = self.res.modify(name='bar', user=3,
+                                     permission_type='admin')
+            self.assertTrue(result['changed'])
 
     def test_modify_permission_by_pk(self):
         with client.test_mode as t:
             existing_registrations(t)
-            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'},
+                            method='PATCH')
             result = self.res.modify(4, permission_type='admin')
+            self.assertTrue(result['changed'])
 
     def test_list_permissions(self):
         with client.test_mode as t:
             existing_registrations(t)
             result = self.res.list(user=3)
+            self.assertEqual(result['count'], 1)

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -17,12 +17,20 @@ import tower_cli
 from tower_cli.api import client
 from tower_cli.utils import exceptions as exc
 
-from tests.compat import unittest, mock
+from tests.compat import unittest
 
-def common_registrations(t):
+
+def create_registrations(t):
     t.register_json('/users/3/permissions/', {'count': 0, 'results': [],
                     'next': None, 'previous': None}, method='GET')
     t.register_json('/users/3/permissions/', {'id': 4}, method='POST')
+
+
+def existing_registrations(t):
+    t.register_json('/users/3/permissions/', {'count': 1,
+                    'results': [{'id': 4, 'name': 'bar'}],
+                    'next': None, 'previous': None}, method='GET')
+    t.register_json('/permissions/4/', {'id': 4}, method='GET')
 
 
 class PermissionTests(unittest.TestCase):
@@ -34,18 +42,53 @@ class PermissionTests(unittest.TestCase):
 
     def test_create_default_permission_type(self):
         with client.test_mode as t:
-            common_registrations(t)
+            create_registrations(t)
             result = self.res.create(
                 name='bar', user=3, inventory=9
             )
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertDictContainsSubset({'id': 4}, result)
-            
+
     def test_create_write_type(self):
         with client.test_mode as t:
-            common_registrations(t)
+            create_registrations(t)
             result = self.res.create(
                 name='bar', user=3, inventory=9, permission_type='write'
             )
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertDictContainsSubset({'id': 4}, result)
+
+    def test_set_base_url_user(self):
+        self.res.set_base_url(1, None)
+        self.assertEqual(self.res.endpoint, '/users/1/permissions/')
+
+    def test_set_base_url_team(self):
+        self.res.set_base_url(None, 1)
+        self.assertEqual(self.res.endpoint, '/teams/1/permissions/')
+
+    def test_no_user_or_team(self):
+        with self.assertRaises(exc.TowerCLIError):
+            self.res.set_base_url(None, None)
+
+    def test_delete_permission(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {}, method='DELETE')
+            result = self.res.delete(name='bar', user=3)
+
+    def test_modify_permission(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            result = self.res.modify(name='bar', user=3, permission_type='admin')
+
+    def test_modify_permission_by_pk(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            t.register_json('/permissions/4/', {'id': 4, 'name': 'bar'}, method='PATCH')
+            result = self.res.modify(4, permission_type='admin')
+
+    def test_list_permissions(self):
+        with client.test_mode as t:
+            existing_registrations(t)
+            result = self.res.list(user=3)

--- a/tests/test_resources_permission.py
+++ b/tests/test_resources_permission.py
@@ -1,0 +1,51 @@
+# Copyright 2016, Red Hat
+# Alan Rominger <arominge@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tower_cli
+from tower_cli.api import client
+from tower_cli.utils import exceptions as exc
+
+from tests.compat import unittest, mock
+
+def common_registrations(t):
+    t.register_json('/users/3/permissions/', {'count': 0, 'results': [],
+                    'next': None, 'previous': None}, method='GET')
+    t.register_json('/users/3/permissions/', {'id': 4}, method='POST')
+
+
+class PermissionTests(unittest.TestCase):
+    """A set of tests for checking that the permission feature works
+    correctly.
+    """
+    def setUp(self):
+        self.res = tower_cli.get_resource('permission')
+
+    def test_create_default_permission_type(self):
+        with client.test_mode as t:
+            common_registrations(t)
+            result = self.res.create(
+                name='bar', user=3, inventory=9
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertDictContainsSubset({'id': 4}, result)
+            
+    def test_create_write_type(self):
+        with client.test_mode as t:
+            common_registrations(t)
+            result = self.res.create(
+                name='bar', user=3, inventory=9, permission_type='write'
+            )
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertDictContainsSubset({'id': 4}, result)


### PR DESCRIPTION
This is a quick fix for the problem that sometimes the prototype permissions feature just failed to take the intended action with the message that `user` or `group` is needed, even when one was provided. It was observed with the `create` command, but it likely affects others as well.

Have tests too now.

Fixes #128 