### PR TITLE
More robust pagination logic

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -689,6 +689,9 @@ class ResourceMethods(BaseResource):
             if not response[key]:
                 continue
             match = re.search(r'page=(?P<num>[\d]+)', response[key])
+            if match is None and key == 'previous':
+                response[key] = 1
+                continue
             response[key] = int(match.groupdict()['num'])
 
         # If we were asked for all pages, keep retrieving pages until we

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -513,6 +513,22 @@ class ResourceTests(unittest.TestCase):
             self.assertEqual(len(t.requests), 3)
             self.assertEqual(len(result['results']), 3)
 
+    def test_list_with_page_1_special_case(self):
+        """Establish that the list function works even if the server gives
+        /foo/ as the relative link for page 1.
+        """
+        with client.test_mode as t:
+            # Register the 2nd page in order to test this.
+            t.register_json('/foo/?page=2', {'count': 2, 'results': [
+                {'id': 2, 'name': 'spam', 'description': 'eggs'},
+            ], 'next': None, 'previous': '/foo/'})
+
+            # Get the list
+            result = self.res.list(page=2)
+
+            # Check that the function knows that /foo/ is page 1
+            self.assertEqual(result['previous'], 1)
+
     def test_list_custom_kwargs(self):
         """Establish that if we pass custom keyword arguments to list, that
         they are included in the final request.


### PR DESCRIPTION
This shouldn't affect most users, but if Tower gives a different format for the first page, this will allow it to work correctly. Corresponding test documents the particular case.