### PR TITLE
Add ability to create group as subgroup of another group

### DIFF
--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -226,6 +226,20 @@ class Resource(models.Resource):
         isid = self._get_inventory_source_id(group)
         return isrc.update(isid, monitor=monitor, timeout=timeout, **kwargs)
 
+    @resources.command(use_fields_as_options=False)
+    @click.option('--group', type=types.Related('group'))
+    @click.option('--parent', type=types.Related('group'))
+    def associate(self, group, parent):
+        """Associate this group with the specified group."""
+        return self._assoc('children', parent, group)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--group', type=types.Related('group'))
+    @click.option('--parent', type=types.Related('group'))
+    def disassociate(self, group, parent):
+        """Disassociate this group from the specified group."""
+        return self._disassoc('children', parent, group)
+
     def _get_inventory_source_id(self, group):
         """Return the inventory source ID given a group dictionary returned
         from the Tower API.

--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -266,3 +266,28 @@ class GroupTests(unittest.TestCase):
                 isrc_sync.assert_called_once_with(42, monitor=False,
                                                   timeout=None)
                 self.assertEqual(len(t.requests), 1)
+
+    def test_set_child_endpoint_id(self):
+        """Test that we can change the endpoint to list children of another
+        group - given the id of parent.
+        """
+        with client.test_mode as t:
+            t.register_json('/groups/1/', {
+                'id': 1, 'inventory': 1, 'name': 'Foo',
+            }, method='GET')
+            self.gr.set_child_endpoint(1)
+            self.assertEqual(self.gr.endpoint, '/groups/1/children/')
+
+    def test_set_child_endpoint_name(self):
+        """Test that we can change the endpoint to list children of another
+        group - given the name of parent.
+        """
+        with client.test_mode as t:
+            t.register_json('/groups/?name=Foo', {
+                'count': 1, 'results': [{
+                    'id': 1, 'inventory': 1, 'name': 'Foo',
+                }],
+                'next': None, 'previous': None,
+            }, method='GET')
+            self.gr.set_child_endpoint("Foo")
+            self.assertEqual(self.gr.endpoint, '/groups/1/children/')

--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -79,6 +79,22 @@ class GroupTests(unittest.TestCase):
                 name='Foo', inventory=1)
             self.assertFalse(answer['changed'])
 
+    def test_create_as_child(self):
+        """Establish that if we start the creation process of a child group
+        """
+        with mock.patch.object(models.Resource, 'create') as super_create:
+            super_create.return_value = {'changed': False, 'id': 1}
+            with mock.patch.object(models.Resource, 'get') as super_get:
+                super_get.return_value = {'id': 2, 'inventory': 1}
+                with client.test_mode as t:
+                    answer = self.gr.create(name='Foo', parent_group=2)
+                    self.assertEqual(len(t.requests), 0)
+                super_get.assert_called_once_with(2)
+            super_create.assert_called_once_with(
+                fail_on_found=False, force_on_exists=False,
+                name='Foo', inventory=1)
+            self.assertFalse(answer['changed'])
+
     def test_create_change_but_no_isource_request_needed(self):
         """Establish that if we make a new group but don't have any interesting
         inventory source arguments, that the group creation stands with no


### PR DESCRIPTION
This allows the following type of command to work where `parent_group` is an existing group and the `child_group` is created.

    tower-cli group create --parent-group=parent_group --name=child_group

This also introduces an error scenario where neither inventory nor group is provided (previously we just returned the error from the server when inventory was not there).