### PR TITLE
Allow starting job with job_tags for superadmins

### DIFF
--- a/lib/tower_cli/api.py
+++ b/lib/tower_cli/api.py
@@ -47,7 +47,7 @@ class Client(Session):
             adapter.max_retries = 3
 
         # Store the authenticated user details.
-        #self.me = (self.get('/me').json())['results'][0]
+        self.me = (self.get('/me').json())['results'][0]
 
     @property
     def prefix(self):

--- a/lib/tower_cli/api.py
+++ b/lib/tower_cli/api.py
@@ -39,15 +39,10 @@ class Client(Session):
 
       [1]: http://docs.python-requests.org/en/latest/
     """
-    me = {}
-
     def __init__(self):
         super(Client, self).__init__()
         for adapter in self.adapters.values():
             adapter.max_retries = 3
-
-        # Store the authenticated user details.
-        self.me = (self.get('/me').json())['results'][0]
 
     @property
     def prefix(self):

--- a/lib/tower_cli/api.py
+++ b/lib/tower_cli/api.py
@@ -39,10 +39,15 @@ class Client(Session):
 
       [1]: http://docs.python-requests.org/en/latest/
     """
+    me = {}
+
     def __init__(self):
         super(Client, self).__init__()
         for adapter in self.adapters.values():
             adapter.max_retries = 3
+
+        # Store the authenticated user details.
+        #self.me = (self.get('/me').json())['results'][0]
 
     @property
     def prefix(self):

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -127,13 +127,13 @@ class Resource(models.ExeResource):
         # step process of posting to /jobs/ and then /jobs/N/start/.
         # For admin users we prefer to use the two step process
         # because more arguments are supported. Like job_tags.
-        supports_job_template_launch = False
+        do_job_template_launch = False
         if 'launch' in jt['related'] and not client.me['is_superuser']:
-            supports_job_template_launch = True
+            do_job_template_launch = True
 
         # Create the new job in Ansible Tower.
         start_data = {}
-        if supports_job_template_launch:
+        if do_job_template_launch:
             endpoint = '/job_templates/%d/launch/' % jt['id']
             if 'extra_vars' in data and len(data['extra_vars']) > 0:
                 start_data['extra_vars'] = data['extra_vars']
@@ -164,7 +164,7 @@ class Resource(models.ExeResource):
 
         # If this used the /job_template/N/launch/ route, get the job
         # ID from the result.
-        if supports_job_template_launch:
+        if do_job_template_launch:
             job_id = job_started.json()['job']
 
         # Get some information about the running job to print

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -122,11 +122,13 @@ class Resource(models.ExeResource):
                 extra_vars_list, force_json=True
             )
 
-        # In Tower 2.1 and later, we create the new job with
+        # In Tower 2.1 and later, non admin users should create the new job with
         # /job_templates/N/launch/; in Tower 2.0 and before, there is a two
         # step process of posting to /jobs/ and then /jobs/N/start/.
+        # For admin users we prefer to use the two step process
+        # because more arguments are supported. Like job_tags.
         supports_job_template_launch = False
-        if 'launch' in jt['related']:
+        if 'launch' in jt['related'] and not client.me['is_superuser']:
             supports_job_template_launch = True
 
         # Create the new job in Ansible Tower.

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -122,13 +122,17 @@ class Resource(models.ExeResource):
                 extra_vars_list, force_json=True
             )
 
-        # In Tower 2.1 and later, non admin users should create the new job with
-        # /job_templates/N/launch/; in Tower 2.0 and before, there is a two
-        # step process of posting to /jobs/ and then /jobs/N/start/.
+        # Get authenticated user details to determine permissions.
+        user = client.get('/me/').json()['results'][0]
+
+        # In Tower 2.1 and later, non admin users should create the new job
+        # with /job_templates/N/launch/; in Tower 2.0 and before,
+        # there is a two step process of posting to /jobs/ and
+        # then /jobs/N/start/.
         # For admin users we prefer to use the two step process
         # because more arguments are supported. Like job_tags.
         do_job_template_launch = False
-        if 'launch' in jt['related'] and not client.me['is_superuser']:
+        if 'launch' in jt['related'] and not user['is_superuser']:
             do_job_template_launch = True
 
         # Create the new job in Ansible Tower.


### PR DESCRIPTION
Allow super admins to start jobs through  `POST /jobs` and `GET /jobs/%d/start`. Which allows the use of providing tags. For other users, use the template `/launch` endpoint.

In order to do this, a call to `/me` had to be made to determine if a user has superuser privileges.

If this is not the way to go, feel free to close this pull request.

See issue: ansible/tower-cli#136