### PR TITLE
Concept to fix inability to disassociate things

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -581,6 +581,11 @@ class ResourceMethods(BaseResource):
             answer.update(existing_data)
             return answer
 
+        # Reinsert None for special case of null association
+        for key in kwargs:
+            if kwargs[key] == 'null':
+                kwargs[key] = None
+
         # Get the URL and method to use for the write.
         url = self.endpoint
         method = 'POST'

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -92,6 +92,10 @@ class Related(click.types.ParamType):
         if re.match(r'^[\d]+$', value):
             return int(value)
 
+        # Special case to allow disassociations
+        if value == 'null':
+            return value
+
         # Okay, we have a string. Try to do a name-based lookup on the
         # resource, and return back the ID that we get from that.
         #

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -728,6 +728,16 @@ class ResourceTests(unittest.TestCase):
             self.assertFalse(result['changed'])
             self.assertIn('name=bar', t.requests[0].url)
 
+    def test_write_with_null_field(self):
+        """Establish that a resource with 'null' field is written."""
+        with client.test_mode as t:
+            t.register_json('/foo/42/', {'id': 42, 'name': 'bar',
+                                         'description': 'baz'}, method='GET')
+            t.register_json('/foo/42/', {'name': 'bar', 'id': 42,
+                                         'inventory': 'null'}, method='PATCH')
+            self.res.write(42, inventory='null')
+            self.assertEqual(json.loads(t.requests[1].body)['inventory'], None)
+
     def test_delete_with_pk(self):
         """Establish that calling `delete` and providing a primary key
         works in the way that we expect.

--- a/tests/test_utils_types.py
+++ b/tests/test_utils_types.py
@@ -75,6 +75,10 @@ class RelatedTests(unittest.TestCase):
         """
         self.assertEqual(self.related.convert(None, 'mything', None), None)
 
+    def test_convert_null_no_record(self):
+        """Establish 'null' passes through as-is"""
+        self.assertEqual(self.related.convert('null', 'mything', None), 'null')
+
     def test_convert_int(self):
         """Establish that if we get an integer sent to the convert method,
         that it's passed through with no action taken on it (idempotency).


### PR DESCRIPTION
This would let people move credentials from user to team ownership, and in general allow telling the API that a field should be "null". The syntax to specify this would be:

> tower-cli resource command 14 --related-field=null

Doing this is a valid action. You don't often have the ability to make that change, but that's aside from the point. The linked issue is a rare scenario where it is absolutely needed.

Fixes #133