### PR TITLE
SSL corner case error and suggestion

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -86,7 +86,7 @@ class ClientTests(unittest.TestCase):
         back from requests, that we deal with it nicely.
         """
         for ErrorType in REQUESTS_ERRORS:
-            with settings.runtime_values(verbose=False):
+            with settings.runtime_values(verbose=False, host='https://foo.co'):
                 with mock.patch.object(Session, 'request') as req:
                     req.side_effect = ErrorType
                     with self.assertRaises(exc.ConnectionError):
@@ -98,7 +98,7 @@ class ClientTests(unittest.TestCase):
         additionally print the internal error if verbose is True.
         """
         for ErrorType in REQUESTS_ERRORS:
-            with settings.runtime_values(verbose=True):
+            with settings.runtime_values(verbose=True, host='https://foo.co'):
                 with mock.patch.object(Session, 'request') as req:
                     req.side_effect = ErrorType
                     with mock.patch.object(debug, 'log') as dlog:


### PR DESCRIPTION
This adds some verbosity to tower-cli in order to prevent a subset of problems that users have encountered with SSL errors.

Firstly, we are going to raise an error for the obviously wrong combination of an `http` host with verify_ssl set.

That still leaves the other possibility that tower-cli automatically attached `https` to the host, against the user's intent. This is tricky, and my past attempts to filter out the error did not work most of the time. So instead, we will tell the user when a SSLError comes up and this _could_ be the case. In retrospect, this looks like the best approach.

Fixes #121 