### PR TITLE
Add new "variables" type field for inventory-related variables

### DIFF
--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -32,7 +32,7 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
-    variables = models.Field(type=types.File('r'), required=False,
+    variables = models.Field(type=types.Variables(), required=False,
                              display=False)
 
     def lookup_with_inventory(self, group, inventory=None):

--- a/lib/tower_cli/resources/group.py
+++ b/lib/tower_cli/resources/group.py
@@ -32,8 +32,9 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
-    variables = models.Field(type=types.Variables(), required=False,
-                             display=False)
+    variables = models.Field(
+        type=types.Variables(), required=False, display=False,
+        help_text='Group variables, use "@" to get from file.')
 
     def lookup_with_inventory(self, group, inventory=None):
         group_res = get_resource('group')

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -28,7 +28,7 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
     enabled = models.Field(type=bool, required=False)
-    variables = models.Field(type=types.File('r'), required=False,
+    variables = models.Field(type=types.Variables(), required=False,
                              display=False)
 
     @resources.command(use_fields_as_options=False)

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -28,8 +28,9 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
     inventory = models.Field(type=types.Related('inventory'))
     enabled = models.Field(type=bool, required=False)
-    variables = models.Field(type=types.Variables(), required=False,
-                             display=False)
+    variables = models.Field(
+        type=types.Variables(), required=False, display=False,
+        help_text='Host variables, use "@" to get from file.')
 
     @resources.command(use_fields_as_options=False)
     @click.option('--host', type=types.Related('host'))

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -25,5 +25,5 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
-    variables = models.Field(type=models.File('r'), required=False,
+    variables = models.Field(type=types.Variables(), required=False,
                              display=False)

--- a/lib/tower_cli/resources/inventory.py
+++ b/lib/tower_cli/resources/inventory.py
@@ -25,5 +25,6 @@ class Resource(models.Resource):
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
     organization = models.Field(type=types.Related('organization'))
-    variables = models.Field(type=types.Variables(), required=False,
-                             display=False)
+    variables = models.Field(
+        type=types.Variables(), required=False, display=False,
+        help_text='Inventory variables, use "@" to get from file.')

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -36,11 +36,12 @@ class File(click.File):
         return super(File, self).convert(value, param, ctx)
 
 
-class Variables(click.types.ParamType):
+class Variables(click.File):
     """Allows reading from a file optionally with '@' prefix,
     otherwise passes through string as-is
     """
     name = 'variables'
+    __name__ = 'variables'
 
     def convert(self, value, param, ctx):
         """Return file content if file, else, return value as-is
@@ -52,8 +53,7 @@ class Variables(click.types.ParamType):
         # Read from a file under these cases
         if value.startswith('@'):
             filename = os.path.expanduser(value[1:])
-            with open(filename, 'r') as f:
-                return f.read().strip('\n')
+            return super(Variables, self).convert(filename, param, ctx)
 
         # No file, use given string
         return value

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -51,7 +51,8 @@ class Variables(click.types.ParamType):
 
         # Read from a file under these cases
         if value.startswith('@'):
-            with open(value[1:], 'r') as f:
+            filename = os.path.expanduser(value[1:])
+            with open(filename, 'r') as f:
                 return f.read().strip('\n')
 
         # No file, use given string

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -36,6 +36,28 @@ class File(click.File):
         return super(File, self).convert(value, param, ctx)
 
 
+class Variables(click.types.ParamType):
+    """Allows reading from a file optionally with '@' prefix,
+    otherwise passes through string as-is
+    """
+    name = 'variables'
+
+    def convert(self, value, param, ctx):
+        """Return file content if file, else, return value as-is
+        """
+        # Protect against corner cases of invalid inputs
+        if not isinstance(value, str):
+            return value
+
+        # Read from a file under these cases
+        if value.startswith('@'):
+            with open(value[1:], 'r') as f:
+                return f.read().strip('\n')
+
+        # No file, use given string
+        return value
+
+
 class MappedChoice(click.Choice):
     """A subclass of click.Choice that allows a distinction between the
     choice sent to the method and the choice typed on the CLI.

--- a/tests/test_utils_types.py
+++ b/tests/test_utils_types.py
@@ -24,7 +24,6 @@ from tower_cli.utils import exceptions as exc, types
 from tower_cli import get_resource
 
 from tests.compat import unittest, mock
-# from tests.compat import mock.mock_open
 
 
 class FileTests(unittest.TestCase):

--- a/tests/test_utils_types.py
+++ b/tests/test_utils_types.py
@@ -52,14 +52,12 @@ class FileTests(unittest.TestCase):
     def test_variables_file(self):
         """Establish that file with variables is opened in this type."""
         f = types.Variables()
-        mock_var = mock.MagicMock()
-        with mock.patch('__builtin__.open', mock_var) as mock_foo:
-            manager = mock_var.return_value.__enter__.return_value
-            manager.read.return_value = "foo: bar"
+        with mock.patch.object(click.File, 'convert') as convert:
+            convert.return_value = "foo: bar"
 
             foo_converted = f.convert('@foobar.yml', 'myfile', None)
 
-            mock_foo.assert_called_once_with("foobar.yml", 'r')
+            convert.assert_called_once_with("foobar.yml", 'myfile', None)
             self.assertEqual(foo_converted, 'foo: bar')
 
     def test_variables_no_file(self):

--- a/tests/test_utils_types.py
+++ b/tests/test_utils_types.py
@@ -24,6 +24,7 @@ from tower_cli.utils import exceptions as exc, types
 from tower_cli import get_resource
 
 from tests.compat import unittest, mock
+# from tests.compat import mock.mock_open
 
 
 class FileTests(unittest.TestCase):
@@ -47,6 +48,31 @@ class FileTests(unittest.TestCase):
             f.convert('~/my_file.txt', 'myfile', None)
             convert.assert_called_with(os.path.expanduser('~/my_file.txt'),
                                        'myfile', None)
+
+    def test_variables_file(self):
+        """Establish that file with variables is opened in this type."""
+        f = types.Variables()
+        mock_var = mock.MagicMock()
+        with mock.patch('__builtin__.open', mock_var) as mock_foo:
+            manager = mock_var.return_value.__enter__.return_value
+            manager.read.return_value = "foo: bar"
+
+            foo_converted = f.convert('@foobar.yml', 'myfile', None)
+
+            mock_foo.assert_called_once_with("foobar.yml", 'r')
+            self.assertEqual(foo_converted, 'foo: bar')
+
+    def test_variables_no_file(self):
+        """Establish that plain variables are passed as-is."""
+        f = types.Variables()
+        foo_converted = f.convert('foo: barz', 'myfile', None)
+        self.assertEqual(foo_converted, 'foo: barz')
+
+    def test_variables_backup_option(self):
+        """Establish that non-string input is protected against."""
+        f = types.Variables()
+        foo_converted = f.convert(54, 'myfile', None)
+        self.assertEqual(foo_converted, 54)
 
 
 class MappedChoiceTests(unittest.TestCase):


### PR DESCRIPTION
This introduces a new field type that allows reading from a file, while also allowing direct input. Just use the "@" at the start to signal that they should be read from a file. Job `extra_vars` is much more complicated of a scenario for several reasons. No attempt is made to combine multiple flags, and no parsing is done. This is for ease of use.

I'm not quite comfortable with putting this in 2.3.2, because it may break existing workflows, but this is up for discussion.

Fixes #104 