### PR TITLE
Host list flag to only list children of group

### DIFF
--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -46,7 +46,8 @@ class Resource(models.Resource):
         return self._disassoc('groups', host, group)
 
     @resources.command(ignore_defaults=True, no_args_is_help=False)
-    @click.option('--group', type=types.Related('group'))
+    @click.option('--group', type=types.Related('group'),
+                  help='List hosts that are children of this group.')
     def list(self, group=None, **kwargs):
         if group:
             kwargs['query'] += (('groups__in', group),)

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -44,3 +44,10 @@ class Resource(models.Resource):
     def disassociate(self, host, group):
         """Disassociate a group from this host."""
         return self._disassoc('groups', host, group)
+
+    @resources.command(ignore_defaults=True, no_args_is_help=False)
+    @click.option('--group', type=types.Related('group'))
+    def list(self, group=None, **kwargs):
+        if group:
+            kwargs['query'] += (('groups__in', group),)
+        return super(Resource, self).list(**kwargs)

--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -50,5 +50,6 @@ class Resource(models.Resource):
                   help='List hosts that are children of this group.')
     def list(self, group=None, **kwargs):
         if group:
-            kwargs['query'] += (('groups__in', group),)
+            kwargs['query'] = (kwargs.get('query', ()) +
+                               (('groups__in', group),))
         return super(Resource, self).list(**kwargs)

--- a/tests/test_resources_host.py
+++ b/tests/test_resources_host.py
@@ -18,7 +18,7 @@ import json
 import tower_cli
 from tower_cli.api import client
 
-from tests.compat import unittest
+from tests.compat import unittest, mock
 
 
 class HostTests(unittest.TestCase):
@@ -52,3 +52,17 @@ class HostTests(unittest.TestCase):
             self.host_resource.disassociate(42, 84)
             self.assertEqual(t.requests[1].body,
                              json.dumps({'disassociate': True, 'id': 84}))
+
+    def test_list_under_group(self):
+        """Establish that a group flag is converted into query string."""
+        with mock.patch(
+                'tower_cli.models.base.ResourceMethods.list') as mock_list:
+            self.host_resource.list(group=78)
+            mock_list.assert_called_once_with(query=(('groups__in', 78),))
+
+    def test_normal_list(self):
+        """Establish that the group flag doesn't break the normal list."""
+        with mock.patch(
+                'tower_cli.models.base.ResourceMethods.list') as mock_list:
+            self.host_resource.list(name="foobar")
+            mock_list.assert_called_once_with(name="foobar")


### PR DESCRIPTION
This adds a supplemental flag for the host list command that narrows the listing to hosts that are children of some group. It is actually just a shortcut for the query string that does this, but it's sufficiently common of a need that I think it makes sense.

Fixes #131 