### PR TITLE
Add RPM specfile and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+VERSION = $(shell cat VERSION)
+
+DISTS = el6 el7
+DIST_SUFFIX_el6 = 
+DIST_SUFFIX_el7 = .centos
+MOCK_CFG_el6 = epel-6-x86_64
+MOCK_CFG_el7 = epel-7-x86_64
+
+.PHONY: all clean $(DISTS)
+.DEFAULT_GOAL = all
+
+define RPM_DIST_RULE
+
+$(eval $(1)_SRPM=rpm-build/ansible-tower-cli-$(VERSION)-1.$(1)$(DIST_SUFFIX_$(1)).src.rpm)
+$(eval $(1)_RPM=rpm-build/ansible-tower-cli-$(VERSION)-1.$(1)$(DIST_SUFFIX_$(1)).noarch.rpm)
+SRPMS += $($(1)_SRPM)
+RPMS += $($(1)_RPM)
+
+$($(1)_SRPM): rpm-build/.exists dist/ansible-tower-cli-$(VERSION).tar.gz packaging/rpm/ansible-tower-cli.spec
+	mock -r $(MOCK_CFG_$(1)) --buildsrpm --spec packaging/rpm/ansible-tower-cli.spec --sources dist/ --resultdir rpm-build
+
+$($(1)_RPM): $($(1)_SRPM)
+	mock -r $(MOCK_CFG_$(1)) --rebuild $($(1)_SRPM) --resultdir rpm-build
+
+$(1): $($(1)_RPM)
+
+endef
+
+$(foreach DIST, $(DISTS), $(eval $(call RPM_DIST_RULE,$(DIST))))
+
+all: $(RPMS)
+
+clean:
+	rm -rf dist
+	rm -rf ansible_tower_cli.egg-info
+	rm -rf rpm-build
+
+dist/ansible-tower-cli-$(VERSION).tar.gz: bin/tower-cli HISTORY.rst LICENSE MANIFEST.in README.rst VERSION requirements.txt setup.py setup.cfg
+	@python setup.py sdist
+
+rpm-build/.exists:
+	mkdir -p rpm-build
+	touch rpm-build/.exists
+
+

--- a/packaging/rpm/ansible-tower-cli.spec
+++ b/packaging/rpm/ansible-tower-cli.spec
@@ -1,0 +1,53 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+Name:           ansible-tower-cli
+Version:        2.3.1
+Release:        1%{?dist}
+Summary:        Commandline interface for Ansible Tower
+Group:          Development/Tools
+License:        ASL 2.0
+URL:            https://github.com/ansible/tower-cli
+Source0:        https://pypi.python.org/packages/f7/7d/ee885225933bb498c34e2ad704194ed188662489a4ca4936a2d82248b6e8/%{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRequires:  python-devel
+BuildRequires:  python-setuptools
+BuildArch:      noarch
+Requires:	python-six >= 1.7.2
+Requires:	PyYAML >= 3.11
+Requires: 	python-requests >= 2.3.0
+Requires:	python-click >= 2.1
+Requires:	python-colorama >= 0.3.1
+
+%description
+ansible-tower-cli is a command line tool for Ansible Tower. It allows Tower
+commands to be easily run from the Unix command line. It can also be
+used as a client library for other python apps, or as a reference for
+others developing API interactions with Tower's REST API.
+
+%prep
+%setup -q
+
+%build
+%{__python} setup.py build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%{__python} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
+
+mkdir -p $RPM_BUILD_ROOT/etc/tower
+touch $RPM_BUILD_ROOT/etc/tower/tower_cli.cfg
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%doc LICENSE README.rst HISTORY.rst
+%config(noreplace) %ghost %{_sysconfdir}/tower/tower_cli.cfg
+%{python_sitelib}/ansible*
+%{python_sitelib}/tower_cli*
+%{_bindir}/*
+
+%changelog
+* Fri Jun 17 2016 Bill Nottingham <notting@ansible.com> - 2.3.1-1
+- initial spec file

--- a/packaging/rpm/ansible-tower-cli.spec
+++ b/packaging/rpm/ansible-tower-cli.spec
@@ -13,7 +13,7 @@ BuildRequires:  python-devel
 BuildRequires:  python-setuptools
 BuildArch:      noarch
 Requires:	python-six >= 1.7.2
-Requires:	PyYAML >= 3.11
+Requires:	PyYAML >= 3.10
 Requires: 	python-requests >= 2.3.0
 Requires:	python-click >= 2.1
 Requires:	python-colorama >= 0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama>=0.3.1
 dict.sorted==1.0.0
 requests>=2.3.0
 six>=1.7.2
-PyYAML>=3.11
+PyYAML>=3.10
 
 # === Python < 2.7 ===
 # importlib>=1.0.3


### PR DESCRIPTION
This PR adds a preliminary RPM build process.

- Spec file by @wenottingham, lightly edited so it works
- Makefile by @ghjm, builds .tar.gz and el6 and el7 RPMs

There is a known issue with an unpackaged dependency on sorted-dict, and there are probably other issues as well. Little to no testing has been done yet.