### PR TITLE
Solve issue #153

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -368,7 +368,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                 for col in columns:
                     widths[col] = max(
                         len(col),
-                        *[len(six.text_type(i[col])) for i in raw_rows]
+                        *[len(six.text_type(i.get(col, 'N/A')))
+                          for i in raw_rows]
                     )
 
                 # It's possible that the column widths will exceed our terminal
@@ -397,8 +398,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                     data_row = ''
                     for col in columns:
                         template = '{0:%d}' % widths[col]
-                        value = raw_row[col]
-                        if isinstance(raw_row[col], bool):
+                        value = raw_row.get(col, 'N/A')
+                        if isinstance(raw_row.get(col, 'N/A'), bool):
                             template = template.replace('{0:', '{0:>')
                             value = six.text_type(value).lower()
                         data_row += template.format(value or '') + ' '

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -73,7 +73,12 @@ class Resource(models.MonitorableResource):
 
         # If we were told to monitor the project update's status, do so.
         if monitor:
-            return self.monitor(inventory_source, timeout=timeout)
+            result = self.monitor(inventory_source, timeout=timeout)
+            inventory = client.get('/inventory_sources/%d/' %
+                                   result['inventory_source'])\
+                              .json()['inventory']
+            result['inventory'] = int(inventory)
+            return result
 
         # Done.
         return {'status': 'ok'}

--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -58,6 +58,8 @@ class UpdateTests(unittest.TestCase):
                             {'can_update': True}, method='GET')
             t.register_json('/inventory_sources/1/update/',
                             {}, method='POST')
+            t.register_json('/inventory_sources/1/', {'inventory': 1},
+                            method='GET')
             with mock.patch.object(type(self.isr), 'monitor') as monitor:
                 self.isr.update(1, monitor=True)
                 monitor.assert_called_once_with(1, timeout=None)


### PR DESCRIPTION
Change `__getitem__` to `get(item, default='N/A')` to handle exception of missing response fields. Now the output is.
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli group sync 2 --monitor
== ======================= ========= 
id          name           inventory 
== ======================= ========= 
 8 many_hosts (many_hosts) N/A
== ======================= ========= 
```

*Update*: Note after further modifications, inventory can be properly shown now.
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli group sync 3 --monitor
== ========= =========     
id   name    inventory 
== ========= ========= 
12 爷爷好 (叫爷爷)         3
== ========= ========= 

```

However, as presented. `_format_human` seems to have insufficient support on unicodes. 