### PR TITLE
Solve issue #156

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -25,7 +25,6 @@ import re
 import sys
 import time
 from copy import copy
-from sdict import adict
 
 import six
 
@@ -946,11 +945,11 @@ class ExeResource(MonitorableResource):
             return job
 
         # Print just the information we need.
-        return adict({
+        return {
             'elapsed': job['elapsed'],
             'failed': job['failed'],
             'status': job['status'],
-        })
+        }
 
     @resources.command
     @click.option('--fail-if-not-running', is_flag=True, default=False,
@@ -977,7 +976,7 @@ class ExeResource(MonitorableResource):
                 raise exc.TowerCLIError('Job not running.')
 
         # Return a success.
-        return adict({'status': 'canceled', 'changed': changed})
+        return {'status': 'canceled', 'changed': changed}
 
 
 class Resource(ResourceMethods):

--- a/lib/tower_cli/resources/inventory_source.py
+++ b/lib/tower_cli/resources/inventory_source.py
@@ -15,8 +15,6 @@
 
 import click
 
-from sdict import adict
-
 from tower_cli import models, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, types, exceptions as exc
@@ -111,8 +109,8 @@ class Resource(models.MonitorableResource):
             return job
 
         # Print just the information we need.
-        return adict({
+        return {
             'elapsed': job['elapsed'],
             'failed': job['failed'],
             'status': job['status'],
-        })
+        }

--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -15,8 +15,6 @@
 
 import click
 
-from sdict import adict
-
 from tower_cli import models, get_resource, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, exceptions as exc, types
@@ -197,8 +195,8 @@ class Resource(models.Resource, models.MonitorableResource):
             return job
 
         # Print just the information we need.
-        return adict({
+        return {
             'elapsed': job['elapsed'],
             'failed': job['failed'],
             'status': job['status'],
-        })
+        }

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -18,8 +18,6 @@ import yaml
 
 from six.moves import StringIO
 
-from sdict import adict
-
 import click
 
 from tower_cli import models, resources
@@ -456,13 +454,16 @@ class SubcommandTests(unittest.TestCase):
         """Establish that a custom dictionary with no ID is made into a
         table and printed as expected.
         """
-        func = self.command._echo_method(lambda: adict(foo='bar', spam='eggs'))
+        func = self.command._echo_method(lambda:
+                                         {'foo': 'bar', 'spam': 'eggs'})
         with mock.patch.object(click, 'secho') as secho:
             with settings.runtime_values(format='human'):
                 func()
             output = secho.mock_calls[-1][1][0]
-        self.assertIn('foo spam', output)
-        self.assertIn('bar eggs', output)
+        self.assertIn('foo', output)
+        self.assertIn('spam', output)
+        self.assertIn('bar', output)
+        self.assertIn('eggs', output)
 
 
 class ResourceTests(unittest.TestCase):


### PR DESCRIPTION
Removed all occurrences of `sdict`. Now the outcome of `status` command becomes:
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli project status 5
========== ====== ======= 
  status   failed elapsed 
========== ====== ======= 
successful  false   5.023
========== ====== ======= 
```

Note I did not modify `requirements.txt` here. Further modifications might be required.