### PR TITLE
Solve issue #163

### DIFF
--- a/lib/tower_cli/resources/project.py
+++ b/lib/tower_cli/resources/project.py
@@ -98,7 +98,7 @@ class Resource(models.Resource, models.MonitorableResource):
             org_resource._assoc('projects', org_pk, project_id)
 
         # if the monitor flag is set, wait for the SCM to update
-        if monitor:
+        if monitor and answer.get('changed', False):
             return self.monitor(project_id, timeout=timeout)
 
         return answer


### PR DESCRIPTION
Apply a stricter if condition to solve #163. A side benefit is to avoid any unwarranted scm updates of existing projects when incorrectly calling `tower-cli project create` with monitor enabled. 