### PR TITLE
Juggle library versions to accommodate installs on RHEL6

### DIFF
--- a/packaging/rpm/ansible-tower-cli.spec
+++ b/packaging/rpm/ansible-tower-cli.spec
@@ -16,6 +16,11 @@ Requires:	python-six >= 1.7.2
 Requires:	PyYAML >= 3.10
 Requires: 	python-requests >= 2.3.0
 Requires:	python-click >= 2.1
+%if 0%{?rhel} == 6
+Requires: python-importlib >= 1.0.2
+Requires: python-ordereddict >= 1.1
+Requires: python-simplejson >= 3.5.3
+%endif
 
 %description
 ansible-tower-cli is a command line tool for Ansible Tower. It allows Tower

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ six>=1.7.2
 PyYAML>=3.10
 
 # === Python < 2.7 ===
-# importlib>=1.0.3
+# importlib>=1.0.2
 # ordereddict>=1.1
 # simplejson>=3.5.3


### PR DESCRIPTION
I'm still looking into testing `python-importlib`, but I'm going to try to get a full install done based off of this branch.