### PR TITLE
Touchup URLs in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,13 +12,13 @@ others developing API interactions with Tower's REST API.
 About Tower
 -----------
 
-`Ansible Tower <http://ansible.com/tower>`__ is a GUI and REST interface
+`Ansible Tower <https://www.ansible.com/tower>`__ is a GUI and REST interface
 for Ansible that supercharges it by adding RBAC, centralized logging,
 autoscaling/provisioning callbacks, graphical inventory editing, and
 more.
 
 Tower is free to use for up to 30 days or 10 nodes. Beyond this, `a
-license is required <http://ansible.com/ansible-pricing>`__.
+license is required <https://www.ansible.com/pricing>`__.
 
 Capabilities
 ------------
@@ -232,7 +232,7 @@ If you want an example for a particular case that this README does not
 cover, the development distribution of tower-cli includes a script that
 populates the Tower server with fake data using tower-cli commands.
 These attempt to cover most of the available features and can be found
-in the folder `/docs/examples/ </docs/examples>`__.
+in the folder `/docs/examples/ <https://github.com/ansible/tower-cli/tree/master/docs/examples>`__.
 
 License
 -------

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -27,7 +27,7 @@ should be all the unique information necessary.
 ### Create Fake Data
 
 You may want to reference the
-[fake data creator](/docs/examples/fake_data_creator.sh) for
+[fake data creator](https://github.com/ansible/tower-cli/blob/master/docs/examples/fake_data_creator.sh) for
 examples on how to create different types of resources.
 
 If you want to run the script, which auto-populates your Tower server

--- a/docs/examples/fake_data_creator.sh
+++ b/docs/examples/fake_data_creator.sh
@@ -21,7 +21,7 @@ echo "        == Tower-CLI DATA FAKER == "
 echo "  Setting up fake data for tower-cli testing"
 echo " "
 
-echo "Tower-CLI DATA FAKER: writing config settings"
+echo "Tower-CLI DATA FAKER: reading config settings"
 hostval=$(tower-cli config host)
 userval=$(tower-cli config username)
 passwordval=$(tower-cli config password)
@@ -36,7 +36,6 @@ fi
 echo " current configuration settings:"
 echo $hostval
 echo $userval
-echo $passwordval
 
 tower-cli config verify_ssl false
 

--- a/docs/examples/fake_data_creator.sh
+++ b/docs/examples/fake_data_creator.sh
@@ -62,8 +62,6 @@ tower-cli project create --name sample_playbooks --organization "Default" --scm-
 # Examples of moving around a project to different organizations and back again
 echo " associating a project with an organization"
 tower-cli organization associate_project --organization="Bio Inc" --project="sample_playbooks"
-echo " disassociating a project with an organization"
-tower-cli organization disassociate_project --organization="Bio Inc" --project="sample_playbooks"
 tower-cli organization associate_project --organization="Hyrule Ventures" --project="sample_playbooks"
 
 echo "Tower-CLI DATA FAKER: creating users"


### PR DESCRIPTION
Changes:

 - use absolute URLs so the PyPi page looks nice 
 - update other URLs
 - the project disassociations in the example script had some cross-version problems, so it gets removed
