### PR TITLE
Add description display option.

### DIFF
--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -87,6 +87,7 @@ class Settings(object):
             'username': '',
             'verify_ssl': 'true',
             'verbose': 'false',
+            'description_on': 'false',
         }
         self._defaults = Parser(defaults=defaults)
         self._defaults.add_section('general')

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -324,7 +324,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
 
                 # What are the columns we will show?
                 columns = [field.name for field in self.resource.fields
-                           if field.display]
+                           if field.display or settings.description_on
+                           and field.name == 'description']
                 columns.insert(0, 'id')
 
                 # Sanity check: If there is a "changed" key in our payload

--- a/lib/tower_cli/utils/decorators.py
+++ b/lib/tower_cli/utils/decorators.py
@@ -43,6 +43,7 @@ def command(method=None, **kwargs):
                 'format': inner_kw.pop('format', None),
                 'username': inner_kw.pop('tower_username', None),
                 'verbose': inner_kw.pop('verbose', None),
+                'description_on': inner_kw.pop('description_on', None),
                 'insecure': inner_kw.pop('insecure', None),
             }
             with settings.runtime_values(**runtime_settings):
@@ -105,6 +106,13 @@ def with_global_options(method):
         '-v', '--verbose',
         default=None,
         help='Show information about requests being made.',
+        is_flag=True,
+        required=False,
+    )(method)
+    method = click.option(
+        '--description-on', '-d',
+        default=None,
+        help='Show description in human-formatted output.',
         is_flag=True,
         required=False,
     )(method)


### PR DESCRIPTION
Connect to issue #33.

Now user can specify `-d` flag to show descriptions:
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli host list --insecure
== ========= ========= ======= 
id   name    inventory enabled 
== ========= ========= ======= 
 1 localhost         1    true
 2 localhost         2    true
== ========= ========= ======= 
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli host list -d --insecure
== ========= =========== ========= ======= 
id   name    description inventory enabled 
== ========= =========== ========= ======= 
 1 localhost hehe                1    true
 2 localhost haha                2    true
== ========= =========== ========= ======= 
```