### PR TITLE
Resolve incorrect error message when creating duplicate item without required field.

### DIFF
--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -509,7 +509,9 @@ class ResourceMethods(BaseResource):
         # Did we get more than one result back?
         # If so, this is also an error, and we need to complain.
         if fail_on_multiple_results and resp['count'] >= 2:
-            raise exc.MultipleResults('Expected one result, got %d. Tighten '
+            raise exc.MultipleResults('Expected one result, got %d. Possibly '
+                                      'caused by not providing required '
+                                      'fields. Please tighten '
                                       'your criteria.' % resp['count'])
 
         # Return the response.


### PR DESCRIPTION
Connect to issue #109.

This issue is caused by the exe sequence of existence checking and required checking. Adding related exception capture gives user log info of possible failure causes.

Now the outcome becomes:
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli host create --name localhost -v --insecure
*** DETAILS: Checking for an existing record. *********************************
GET https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/hosts/
Params: {'name': u'localhost'}

*** WARNING: Multiple Results found. Possibly caused by missing required options. 
Error: Missing required fields: inventory
```