### PR TITLE
Add --use-job-endpoint option for job launch.

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import, unicode_literals
 from copy import copy
 from getpass import getpass
 from distutils.version import LooseVersion
-from ast import literal_eval
 
 import click
 
@@ -78,9 +77,11 @@ class Resource(models.ExeResource):
         '--credential', required=False, type=types.Related('credential'),
         help='Specify machine credential for job template to run.'
     )
-    def launch(self, job_template=None, tags=None, monitor=False, timeout=None,
-               no_input=True, extra_vars=None, limit=None, job_type=None,
-               inventory=None, credential=None, **kwargs):
+    @click.option('--use-job-endpoint', required=False, default=False,
+                  is_flag=True, help='A flag that disable launching jobs'
+                  ' from job template when set.')
+    def launch(self, job_template=None, monitor=False, timeout=None,
+               no_input=True, extra_vars=None, **kwargs):
         """Launch a new job based on a job template.
 
         Creates a new job in Ansible Tower, immediately starts it, and
@@ -89,6 +90,8 @@ class Resource(models.ExeResource):
         # Get the job template from Ansible Tower.
         # This is used as the baseline for starting the job.
 
+        tags = kwargs.get('tags', None)
+        use_job_endpoint = kwargs.pop('use_job_endpoint', False)
         jt_resource = get_resource('job_template')
         jt = jt_resource.get(job_template)
 
@@ -140,7 +143,7 @@ class Resource(models.ExeResource):
         for resource in PROMPT_LIST:
             if data.pop('ask_' + resource + '_on_launch', False) \
                and not no_input:
-                resource_object = literal_eval(resource)
+                resource_object = kwargs.get(resource, None)
                 if type(resource_object) == types.Related:
                     resource_class = get_resource(resource)
                     resource_object = resource_class.get(resource).\
@@ -167,7 +170,7 @@ class Resource(models.ExeResource):
 
         # Create the new job in Ansible Tower.
         start_data = {}
-        if supports_job_template_launch:
+        if supports_job_template_launch and not use_job_endpoint:
             endpoint = '/job_templates/%d/launch/' % jt['id']
             if 'extra_vars' in data and len(data['extra_vars']) > 0:
                 start_data['extra_vars'] = data['extra_vars']
@@ -201,7 +204,7 @@ class Resource(models.ExeResource):
 
         # If this used the /job_template/N/launch/ route, get the job
         # ID from the result.
-        if supports_job_template_launch:
+        if supports_job_template_launch and not use_job_endpoint:
             job_id = job_started.json()['job']
 
         # Get some information about the running job to print

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -142,15 +142,16 @@ class Resource(models.ExeResource):
         modified = set()
         for resource in PROMPT_LIST:
             if data.pop('ask_' + resource + '_on_launch', False) \
-               and not no_input:
+               and not no_input or use_job_endpoint:
                 resource_object = kwargs.get(resource, None)
                 if type(resource_object) == types.Related:
                     resource_class = get_resource(resource)
                     resource_object = resource_class.get(resource).\
                         pop('id', None)
                 if resource_object is None:
-                    debug.log('{0} is asked at launch but not provided'.
-                              format(resource), header='warning')
+                    if not use_job_endpoint:
+                        debug.log('{0} is asked at launch but not provided'.
+                                  format(resource), header='warning')
                 elif resource != 'tags':
                     data[resource] = resource_object
                     modified.add(resource)

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -319,6 +319,26 @@ class LaunchTests(unittest.TestCase):
                 getpass.assert_called_once_with('Password for foo: ')
             self.assertDictContainsSubset({'changed': True, 'id': 42}, result)
 
+    def test_launch_with_use_job_endpoint_set(self):
+        """Establish that launching a job with `--use-job-endpoint` set would
+        launch job through /jobs/\d/ endpoint regardless of the existance of
+        /job_templates/\d/launch/ endpoint
+        """
+        jt = {
+            'related': {
+                'launch': '/api/v1/job_templates/1/launch/'
+            },
+            'id': 1,
+            'name': 'demo'
+        }
+        with client.test_mode as t:
+            t.register_json('/job_templates/1/', jt)
+            t.register_json('/jobs/16/', {})
+            t.register_json('/jobs/', {'id': 16}, method='POST')
+            t.register_json('/jobs/16/start/', {})
+            t.register_json('/jobs/16/start/', {}, method='POST')
+            self.res.launch(job_template=1, use_job_endpoint=True)
+
 
 class StatusTests(unittest.TestCase):
     """A set of tests to establish that the job status command works in the


### PR DESCRIPTION
Connect to #136.

Now user can use this flag to disable `/job_templates/\d/launch/` endpoint during job launch.
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli job launch --job-template 5 --use-job-endpoint -v
*** DETAILS: Getting the record. **********************************************
GET https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/job_templates/5/
Params: {}

*** DETAILS: Creating the job. ************************************************
POST https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/jobs/
Data: {u'type': u'job_template', u'url': u'/api/v1/job_templates/5/', u'related': {u'created_by': u'/api/v1/users/1/', u'labels': u'/api/v1/job_templates/5/labels/', u'inventory': u'/api/v1/inventories/1/', u'project': u'/api/v1/projects/4/', u'credential': u'/api/v1/credentials/1/', u'last_job': u'/api/v1/jobs/14/', u'notification_templates_error': u'/api/v1/job_templates/5/notification_templates_error/', u'notification_templates_success': u'/api/v1/job_templates/5/notification_templates_success/', u'jobs': u'/api/v1/job_templates/5/jobs/', u'object_roles': u'/api/v1/job_templates/5/object_roles/', u'notification_templates_any': u'/api/v1/job_templates/5/notification_templates_any/', u'access_list': u'/api/v1/job_templates/5/access_list/', u'launch': u'/api/v1/job_templates/5/launch/', u'schedules': u'/api/v1/job_templates/5/schedules/', u'activity_stream': u'/api/v1/job_templates/5/activity_stream/', u'survey_spec': u'/api/v1/job_templates/5/survey_spec/'}, u'summary_fields': {u'last_job': {u'id': 14, u'name': u'Demo Job Template [invoked via. Tower CLI]', u'description': u'', u'finished': u'2016-07-29T19:54:24.419Z', u'status': u'successful', u'failed': False}, u'last_update': {u'id': 14, u'name': u'Demo Job Template [invoked via. Tower CLI]', u'description': u'', u'status': u'successful', u'failed': False}, u'inventory': {u'id': 1, u'name': u'Demo Inventory', u'description': u'', u'has_active_failures': False, u'total_hosts': 1, u'hosts_with_active_failures': 0, u'total_groups': 0, u'groups_with_active_failures': 0, u'has_inventory_sources': False, u'total_inventory_sources': 0, u'inventory_sources_with_failures': 0}, u'credential': {u'id': 1, u'name': u'Demo Credential', u'description': u'', u'kind': u'ssh', u'cloud': False}, u'project': {u'id': 4, u'name': u'Demo Project', u'description': u'', u'status': u'successful'}, u'created_by': {u'id': 1, u'username': u'admin', u'first_name': u'', u'last_name': u''}, u'object_roles': {u'admin_role': {u'description': u'Can manage all aspects of the job template', u'id': 20, u'name': u'Admin'}, u'execute_role': {u'description': u'May run the job template', u'id': 22, u'name': u'Execute'}, u'read_role': {u'description': u'May view settings for the job template', u'id': 21, u'name': u'Read'}}, u'labels': {u'count': 9, u'results': [{u'id': 10, u'name': u'doushitui'}, {u'id': 6, u'name': u'fafa'}, {u'id': 7, u'name': u'guagua'}, {u'id': 3, u'name': u'haha'}, {u'id': 1, u'name': u'hey'}, {u'id': 4, u'name': u'hoho'}, {u'id': 8, u'name': u'kaka'}, {u'id': 9, u'name': u'touyixia'}, {u'id': 5, u'name': u'xiaxia'}]}, u'can_copy': True, u'can_edit': True, u'recent_jobs': [{u'status': u'successful', u'finished': u'2016-07-29T19:54:24.419Z', u'id': 14}, {u'status': u'successful', u'finished': u'2016-07-29T18:47:15.993Z', u'id': 12}, {u'status': u'successful', u'finished': u'2016-07-29T18:46:03.525Z', u'id': 10}, {u'status': u'successful', u'finished': u'2016-07-27T21:28:58.521Z', u'id': 8}, {u'status': u'successful', u'finished': u'2016-07-27T21:25:57.493Z', u'id': 6}, {u'status': u'successful', u'finished': u'2016-07-21T13:53:01.004Z', u'id': 2}]}, u'created': u'2016-07-21T13:49:56.384Z', u'modified': u'2016-07-29T19:52:06.800Z', u'name': u'Demo Job Template [invoked via. Tower CLI]', u'description': u'', u'job_type': u'run', u'inventory': 1, u'project': 4, u'playbook': u'hello_world.yml', u'credential': 1, u'cloud_credential': None, u'network_credential': None, u'forks': 0, u'limit': u'', u'verbosity': 0, u'job_tags': u'', u'force_handlers': False, u'skip_tags': u'', u'start_at_task': u'', u'last_job_run': u'2016-07-29T19:54:24.419178Z', u'last_job_failed': False, u'has_schedules': False, u'next_job_run': None, u'status': u'successful', u'host_config_key': u'', u'survey_enabled': False, u'become_enabled': False, u'allow_simultaneous': False, u'job_template': 5}

*** DETAILS: Asking for information necessary to start the job. ***************
GET https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/jobs/16/start/
Params: {}

*** DETAILS: Launching the job. ***********************************************
POST https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/jobs/16/start/
Data: {}

*** DETAILS: Asking for job status. *******************************************
GET https://ec2-54-234-179-218.compute-1.amazonaws.com/api/v1/jobs/16/
Params: {}

== ============ ======================== ======= ======= 
id job_template         created          status  elapsed 
== ============ ======================== ======= ======= 
16            5 2016-07-29T19:58:02.571Z pending
== ============ ======================== ======= =======
```

Note setting this flag will disable any prompt checkbox ---- jobs will be created with provided prompt-for fields regardless of whether their checkboxes on the server side is checked or not.