### PR TITLE
Remove duplicate field in roles.py

### DIFF
--- a/lib/tower_cli/resources/role.py
+++ b/lib/tower_cli/resources/role.py
@@ -29,7 +29,7 @@ from tower_cli.conf import settings
 ACTOR_FIELDS = ['user', 'team']
 
 RESOURCE_FIELDS = [
-    'target_team', 'credential', 'inventory', 'job_template', 'credential',
+    'target_team', 'credential', 'inventory', 'job_template',
     'organization', 'project']
 
 ROLE_TYPES = [


### PR DESCRIPTION
This prevented users from granting roles to credentials, and it was a straight-forward bug.