### PR TITLE
Include remote tower version into config files.

### DIFF
--- a/lib/tower_cli/commands/version.py
+++ b/lib/tower_cli/commands/version.py
@@ -31,7 +31,7 @@ def version():
     """Display version information."""
 
     # Attempt to connect to the Ansible Tower server.
-    # If we succeed, assign the version variable; if not, 
+    # If we succeed, assign the version variable; if not,
     # set no-connection flag.
     try:
         r = client.get('/config/')


### PR DESCRIPTION
Connect to issue #185.

Now config file will include a new section `[remote]` with one field `version` that keeps record of the latest known tower server version (which is learnt by calling `tower-cli version`).
```
(tower_cli_devel) sitan-OSX:~ sitan$ cat .tower_cli.cfg | sed -n /^version/p
(tower_cli_devel) sitan-OSX:~ sitan$ tower-cli version
Ansible Tower 3.0.0
Tower CLI 2.3.2
(tower_cli_devel) sitan-OSX:~ sitan$ cat .tower_cli.cfg | sed -n /^version/p
version = 3.0.0
```
Calling version command with connection errors but previous record on file will display that record. *Be careful as the version might not be the actual current tower version!*
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli version
Fetching previous record due to connection error, the result might be deprecated...
Ansible Tower 3.0.0
Tower CLI 2.3.2
```
Error will be triggered if connection error and no version on file.
```
(tower_cli_devel) sitan-OSX:~ sitan$ cat .tower_cli.cfg | sed -n /^version/p
(tower_cli_devel) sitan-OSX:~ sitan$ tower-cli version
Error: Could not connect to Ansible Tower and no previous record available.
```