### PR TITLE
Add supports for tower-cli version.

### DIFF
--- a/bin/tower-cli
+++ b/bin/tower-cli
@@ -21,6 +21,7 @@ import sys
 import click
 
 import tower_cli
+from tower_cli import __version__
 from tower_cli.utils import secho
 
 
@@ -74,7 +75,16 @@ class TowerCLI(click.MultiCommand):
         secho('No such command: %s.' % name, fg='red', bold=True)
         sys.exit(2)
 
+    def invoke(self, ctx):
+        if ctx.params.get('version', False):
+            click.echo('Tower CLI %s' % __version__)
+        else:
+            return super(TowerCLI, self).invoke(ctx)
+
 
 if __name__ == '__main__':
-    cli = TowerCLI()
+    cli = TowerCLI(
+        params=[click.Option(param_decls=['--version'], is_flag=True,
+                             help='Display tower-cli version.')],
+    )
     cli()

--- a/lib/tower_cli/commands/version.py
+++ b/lib/tower_cli/commands/version.py
@@ -28,6 +28,9 @@ from tower_cli.utils.exceptions import TowerCLIError
 def version():
     """Display version information."""
 
+    # Print out the current version of Tower CLI.
+    click.echo('Tower CLI %s' % __version__)
+
     # Attempt to connect to the Ansible Tower server.
     # If we succeed, print a version; if not, generate a failure.
     try:
@@ -36,6 +39,3 @@ def version():
     except RequestException as ex:
         raise TowerCLIError('Could not connect to Ansible Tower.\n%s' %
                             six.text_type(ex))
-
-    # Print out the current version of Tower CLI.
-    click.echo('Tower CLI %s' % __version__)

--- a/tests/test_commands_version.py
+++ b/tests/test_commands_version.py
@@ -45,7 +45,7 @@ class VersionTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output.strip(),
-                'Ansible Tower 4.21\nTower CLI %s' % tower_cli.__version__,
+                'Tower CLI %s\nAnsible Tower 4.21' % tower_cli.__version__,
             )
 
     def test_cannot_connect(self):


### PR DESCRIPTION
Connect to #185 .

Now new base option `--version` is added to support tower-cli version lookup, and sequence of displaying cli version and tower version is reversed.
```
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli --version
Tower CLI 2.3.2
(tower_cli_devel) sitan-OSX:tower-cli sitan$ tower-cli version
Tower CLI 2.3.2
Ansible Tower 3.0.0
```