### PR TITLE
Bundle some commands into Makefile to ease devel installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,7 @@ rpm-build/.exists:
 	mkdir -p rpm-build
 	touch rpm-build/.exists
 
-
+# For devel convinience
+install:
+	sudo rm -rf dist/ build/ 
+	sudo python setup.py install


### PR DESCRIPTION
Now typing `make install` would do both clean-up and installation.