### PR TITLE
Make travis test to be run properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox-travis
     - pip install coveralls
 before_script:
-    flake8 .
+    if [[ $TRAVIS_PYTHON_VERSION > 2.6 ]]; then falke8 .; fi
 script:
     - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: false
 language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "pypy"
 env:
-    - TOXENV=py2.6
-    - TOXENV=py2.7
-    - TOXENV=py3.3
-    - TOXENV=py3.4
     - TOXENV=flake8
 install:
     - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
     - TOXENV=flake8
 install:
     - pip install flake8
-    - pip install tox coveralls --use-mirrors
+    - pip install tox
+    - pip install coveralls
 script:
     - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
     - "3.5"
 install:
     - pip install flake8
-    - pip install tox
+    - pip install tox-travis
     - pip install coveralls
 before_script:
     flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox-travis
     - pip install coveralls
 before_script:
-    if [[ $TRAVIS_PYTHON_VERSION > 2.6 ]]; then falke8 .; fi
+    - test $TRAVIS_PYTHON_VERSION != '2.6' && falke8 .
 script:
     - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox-travis
     - pip install coveralls
 before_script:
-    test $TRAVIS_PYTHON_VERSION != '2.6' && flake8 .
+    if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then flake8 . ; fi
 script:
     - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
-    - "pypy"
-env:
-    - TOXENV=flake8
 install:
     - pip install flake8
     - pip install tox
     - pip install coveralls
+before_script:
+    flake8 .
 script:
     - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install tox-travis
     - pip install coveralls
 before_script:
-    - test $TRAVIS_PYTHON_VERSION != '2.6' && falke8 .
+    test $TRAVIS_PYTHON_VERSION != '2.6' && flake8 .
 script:
     - tox
 after_success:

--- a/lib/tower_cli/models/base.py
+++ b/lib/tower_cli/models/base.py
@@ -347,8 +347,8 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
 
                 # What are the columns we will show?
                 columns = [field.name for field in self.resource.fields
-                           if field.display or settings.description_on
-                           and field.name == 'description']
+                           if field.display or settings.description_on and
+                           field.name == 'description']
                 columns.insert(0, 'id')
 
                 # Sanity check: If there is a "changed" key in our payload

--- a/lib/tower_cli/utils/parser.py
+++ b/lib/tower_cli/utils/parser.py
@@ -19,6 +19,7 @@ import json
 import ast
 import shlex
 import sys
+import six
 
 from tower_cli.utils import exceptions as exc, debug
 from tower_cli.utils.data_structures import OrderedDict
@@ -48,7 +49,7 @@ def parse_kv(var_string):
 
         # Second part of fix to avoid passing shlex unicode in py2.6
         if fix_encoding_26:
-            token = unicode(token)
+            token = six.text_type(token)
         # Look for key=value pattern, if not, process as raw parameter
         if '=' in token:
             (k, v) = token.split('=', 1)

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 import sys
 from distutils.core import setup
-from os.path import dirname, realpath
-from os import sep
 from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 
@@ -32,6 +29,7 @@ class Tox(TestCommand):
     Based on http://tox.readthedocs.org/en/latest/example/basic.html
     """
     user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.tox_args = ""
@@ -45,6 +43,7 @@ class Tox(TestCommand):
         import tox  # Import here, because outside eggs aren't loaded.
         import shlex
         sys.exit(tox.cmdline(args=shlex.split(self.tox_args)))
+
 
 def parse_requirements(filename):
     """Parse out a list of requirements from the given requirements
@@ -100,6 +99,7 @@ def parse_requirements(filename):
     # Okay, we should have an entire list of requirements now.
     return reqs
 
+
 def combine_files(*args):
     """returns a string of all the strings in *args combined together,
     with two line breaks between them"""
@@ -137,7 +137,7 @@ setup(
 
     # How to do the tests
     tests_require=['tox'],
-    cmdclass={'test': Tox },
+    cmdclass={'test': Tox},
 
     # Data files
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py3.4,
-    py3.3,
-    py2.7,
-    py2.6,
+    py35,
+    py34,
+    py33,
+    py27,
+    py26,
     flake8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py{26,27,33,34,35}
-
 [testenv]
 commands =
     nosetests {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,11 @@ deps =
 
 
 [testenv:py27]
-basepython = python2.7
 deps =
     {[testenv]deps}
     mock
 
 [testenv:py26]
-basepython = python2.6
 deps =
     {[testenv:py27]deps}
     importlib

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,7 @@
 [tox]
-envlist =
-    py35,
-    py34,
-    py33,
-    py27,
-    py26,
-    flake8
+envlist = py{26,27,33,34,35}
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/lib/
-
 commands =
     nosetests {posargs}
 
@@ -19,24 +10,11 @@ deps =
     -r{toxinidir}/tests/requirements.txt
 
 
-[testenv:py35]
-basepython = python3.5
-
-
-[testenv:py34]
-basepython = python3.4
-
-
-[testenv:py33]
-basepython = python3.3
-
-
 [testenv:py27]
 basepython = python2.7
 deps =
     {[testenv]deps}
     mock
-
 
 [testenv:py26]
 basepython = python2.6
@@ -46,9 +24,3 @@ deps =
     ordereddict
     simplejson
     unittest2
-
-
-[testenv:flake8]
-deps = flake8
-commands =
-    flake8 lib tests

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
 [testenv:py26]
 basepython = python2.6
 deps =
-    {[testenv:py2.7]deps}
+    {[testenv:py27]deps}
     importlib
     ordereddict
     simplejson

--- a/tox.ini
+++ b/tox.ini
@@ -19,22 +19,26 @@ deps =
     -r{toxinidir}/tests/requirements.txt
 
 
-[testenv:py3.4]
+[testenv:py35]
+basepython = python3.5
+
+
+[testenv:py34]
 basepython = python3.4
 
 
-[testenv:py3.3]
+[testenv:py33]
 basepython = python3.3
 
 
-[testenv:py2.7]
+[testenv:py27]
 basepython = python2.7
 deps =
     {[testenv]deps}
     mock
 
 
-[testenv:py2.6]
+[testenv:py26]
 basepython = python2.6
 deps =
     {[testenv:py2.7]deps}


### PR DESCRIPTION
- Make travis informed of py3.5 (makes #205 testable)
- Make travis run flake8 for every python version
- Make travis run on the right version of python (fixes #208)

This PR make it not performing tests properly on Py2.6 and Py3.5, but this is the whole point of this PR