### PR TITLE
Use documented test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,4 +196,4 @@ class ClientTests(unittest.TestCase):
                 with mock.patch.object(click, 'secho') as secho:
                     with self.assertRaises(exc.ConnectionError):
                         client.get('/ping/')
-                    secho.assert_called()
+                    self.assertTrue(secho.called)


### PR DESCRIPTION
the assert_called() property is not documented and seems to be absent in py3.5