### PR TITLE
Introduce Standard Out Streaming with wait as old monitoring

### DIFF
--- a/tests/test_models_unified_jobs.py
+++ b/tests/test_models_unified_jobs.py
@@ -62,7 +62,7 @@ class StandardOutTests(unittest.TestCase):
                     lookup.return_value = 'foobar'
                     result = self.res.stdout(42)
                     assert not result['changed']
-                    mock_echo.assert_called_once_with('foobar', nl=0)
+                    mock_echo.assert_called_once_with('foobar', nl=1)
 
     def test_stdout_with_lookup(self):
         "Test that unified job will be automatically looked up."

--- a/tests/test_models_unified_jobs.py
+++ b/tests/test_models_unified_jobs.py
@@ -1,0 +1,96 @@
+# Copyright 2016, Ansible by Red Hat
+# Alan Rominger <arominge@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import click
+
+import tower_cli
+from tower_cli.api import client
+
+from tests.compat import unittest, mock
+
+
+def project_update_registration(t):
+    t.register_json('/project_updates/54/', {
+        'elapsed': 1335024000.0,
+        'failed': False,
+        'status': 'successful',
+    }, method='GET')
+
+
+class StandardOutTests(unittest.TestCase):
+    """
+    Test that standard out lookup and wrapper methods
+    """
+    def setUp(self):
+        # Representative of a Unified Job Template
+        self.res = tower_cli.get_resource('project')
+        # Representative of a Unified Job
+        self.job_res = tower_cli.get_resource('job')
+
+    def test_lookup_stdout(self):
+        "Test the method that makes a call to get standard out."
+        with client.test_mode as t:
+            # note:
+            # 'foobar' = 'Zm9vYmFy' via
+            # base64.standard_b64encode('foobar'.encode('ascii'))
+            # but python versions can't all agree on how to trim the string
+            t.register_json(
+                '/project_updates/42/stdout/',
+                {'content': 'Zm9vYmFy'}, method='GET')
+            stdout = self.res.lookup_stdout(42, start_line=0, end_line=1)
+            assert 'foobar' in str(stdout)
+
+    def test_stdout(self):
+        "Test that printing standard out works with project-like things."
+        with mock.patch.object(type(self.res), 'lookup_stdout') as lookup:
+            with mock.patch.object(type(self.res), 'last_job_data') as job:
+                with mock.patch.object(click, 'echo') as mock_echo:
+                    job.return_value = {'id': 42}
+                    lookup.return_value = 'foobar'
+                    result = self.res.stdout(42)
+                    assert not result['changed']
+                    mock_echo.assert_called_once_with('foobar', nl=0)
+
+    def test_stdout_with_lookup(self):
+        "Test that unified job will be automatically looked up."
+        with mock.patch.object(type(self.job_res), 'lookup_stdout'):
+            with mock.patch.object(type(self.job_res), 'get') as get:
+                with mock.patch.object(click, 'echo'):
+                    self.job_res.stdout(pk=None, name="test-proj")
+                    get.assert_called_once_with(name="test-proj")
+
+    def test_call_wait_with_parent(self):
+        "Test auto-lookup of last job is called for wait"
+        with client.test_mode as t:
+            project_update_registration(t)
+            with mock.patch.object(type(self.res), 'last_job_data') as job:
+                job.return_value = {'id': 54}
+                with mock.patch.object(click, 'echo'):
+                    with mock.patch.object(time, 'sleep'):
+                        self.res.wait(pk=None, parent_pk=42)
+                        job.assert_called_once_with(42)
+
+    def test_call_monitor_with_parent(self):
+        "Test auto-lookup when the monitor method is called"
+        with client.test_mode as t:
+            project_update_registration(t)
+            with mock.patch.object(type(self.res), 'last_job_data') as job:
+                job.return_value = {'id': 54}
+                with mock.patch.object(click, 'echo'):
+                    with mock.patch.object(type(self.res), 'wait'):
+                        with mock.patch.object(time, 'sleep'):
+                            self.res.monitor(pk=None, parent_pk=42)
+                            job.assert_called_once_with(42)

--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -62,11 +62,11 @@ class UpdateTests(unittest.TestCase):
                             method='GET')
             with mock.patch.object(type(self.isr), 'monitor') as monitor:
                 self.isr.update(1, monitor=True)
-                monitor.assert_called_once_with(32, 1, timeout=None)
+                monitor.assert_called_once_with(32, parent_pk=1, timeout=None)
             # Check wait method, following same pattern
             with mock.patch.object(type(self.isr), 'wait') as wait:
                 self.isr.update(1, wait=True)
-                wait.assert_called_once_with(32, timeout=None)
+                wait.assert_called_once_with(32, parent_pk=1, timeout=None)
 
 
 class StatusTests(unittest.TestCase):

--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -57,12 +57,16 @@ class UpdateTests(unittest.TestCase):
             t.register_json('/inventory_sources/1/update/',
                             {'can_update': True}, method='GET')
             t.register_json('/inventory_sources/1/update/',
-                            {}, method='POST')
+                            {'inventory_update': 32}, method='POST')
             t.register_json('/inventory_sources/1/', {'inventory': 1},
                             method='GET')
             with mock.patch.object(type(self.isr), 'monitor') as monitor:
                 self.isr.update(1, monitor=True)
-                monitor.assert_called_once_with(1, timeout=None)
+                monitor.assert_called_once_with(32, 1, timeout=None)
+            # Check wait method, following same pattern
+            with mock.patch.object(type(self.isr), 'wait') as wait:
+                self.isr.update(1, wait=True)
+                wait.assert_called_once_with(32, timeout=None)
 
 
 class StatusTests(unittest.TestCase):

--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -565,8 +565,8 @@ class MonitorWaitTests(unittest.TestCase):
                                 type(self.res), 'lookup_stdout'):
                             self.res.monitor(42, min_interval=0.21)
 
-            # We should have gotten two requests total, to the same URL.
-            self.assertEqual(len(t.requests), 2)
+            # We should have gotten 3 requests total, to the same URL.
+            self.assertEqual(len(t.requests), 3)
             self.assertEqual(t.requests[0].url, t.requests[1].url)
 
     def test_timeout(self):

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -100,8 +100,8 @@ class CreateTests(unittest.TestCase):
             self.assertEqual(t.requests[1].method, 'POST')
             self.assertEqual(len(t.requests), 2)
 
-    def test_create_monitor(self):
-        """Establish that a project can be created with the monitor flag
+    def test_create_wait(self):
+        """Establish that a project can be created with the wait flag
         enabled and still sucessfully exit and complete.
         """
         with client.test_mode as t:
@@ -112,7 +112,7 @@ class CreateTests(unittest.TestCase):
                             method='GET')
             t.register_json('/projects/', {'changed': True, 'id': 42},
                             method='POST')
-            # Endpoints related to monitoring the resource
+            # Endpoints related to waiting for the resource
             t.register_json(
                 '/projects/42/', {
                     'status': 'successful',
@@ -125,7 +125,7 @@ class CreateTests(unittest.TestCase):
                 method='GET'
             )
 
-            result = self.res.create(name='bar', scm_type="git", monitor=True)
+            result = self.res.create(name='bar', scm_type="git", wait=True)
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertEqual(t.requests[-1].method, 'GET')
             self.assertDictContainsSubset({'changed': True}, result)
@@ -187,7 +187,11 @@ class UpdateTests(unittest.TestCase):
                             method='POST')
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.update(1, monitor=True)
-                monitor.assert_called_once_with(1, timeout=None)
+                monitor.assert_called_once_with(42, 1, timeout=None)
+            # Test wait method, which follows same pattern
+            with mock.patch.object(type(self.res), 'wait') as wait:
+                self.res.update(1, wait=True)
+                wait.assert_called_once_with(42, timeout=None)
 
     def test_cannot_update(self):
         """Establish that attempting to update a non-updatable project

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -187,11 +187,11 @@ class UpdateTests(unittest.TestCase):
                             method='POST')
             with mock.patch.object(type(self.res), 'monitor') as monitor:
                 self.res.update(1, monitor=True)
-                monitor.assert_called_once_with(42, 1, timeout=None)
+                monitor.assert_called_once_with(42, parent_pk=1, timeout=None)
             # Test wait method, which follows same pattern
             with mock.patch.object(type(self.res), 'wait') as wait:
                 self.res.update(1, wait=True)
-                wait.assert_called_once_with(42, timeout=None)
+                wait.assert_called_once_with(42, parent_pk=1, timeout=None)
 
     def test_cannot_update(self):
         """Establish that attempting to update a non-updatable project

--- a/tower_cli/resources/ad_hoc.py
+++ b/tower_cli/resources/ad_hoc.py
@@ -77,6 +77,9 @@ class Resource(models.ExeResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `monitor` on the newly '
                        'launched command rather than exiting with a success.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Monitor the status of the job, but do not print '
+                       'while job is in progress.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this attempt'
                        ' will time out after the given number of seconds. '
@@ -84,7 +87,8 @@ class Resource(models.ExeResource):
     @click.option('--become', required=False, is_flag=True,
                   help='If used, privledge escalation will be enabled for '
                        'this command.')
-    def launch(self, monitor=False, timeout=None, become=False, **kwargs):
+    def launch(self, monitor=False, wait=False, timeout=None, become=False,
+               **kwargs):
         """Launch a new ad-hoc command.
 
         Runs a user-defined command from Ansible Tower, immediately starts it,
@@ -115,6 +119,8 @@ class Resource(models.ExeResource):
         # monitor from here.
         if monitor:
             return self.monitor(command_id, timeout=timeout)
+        elif wait:
+            return self.wait(command_id, timeout=timeout)
 
         # Return the command ID and other response data
         answer = OrderedDict((

--- a/tower_cli/resources/inventory_source.py
+++ b/tower_cli/resources/inventory_source.py
@@ -79,10 +79,13 @@ class Resource(models.MonitorableResource):
         if monitor or wait:
             inventory_update_id = r.json()['inventory_update']
             if monitor:
-                result = self.monitor(inventory_update_id, inventory_source,
-                                      timeout=timeout)
+                result = self.monitor(
+                    inventory_update_id, parent_pk=inventory_source,
+                    timeout=timeout)
             elif wait:
-                result = self.wait(inventory_update_id, timeout=timeout)
+                result = self.wait(
+                    inventory_update_id, parent_pk=inventory_source,
+                    timeout=timeout)
             inventory = client.get('/inventory_sources/%d/' %
                                    result['inventory_source'])\
                               .json()['inventory']
@@ -92,6 +95,7 @@ class Resource(models.MonitorableResource):
         # Done.
         return {'status': 'ok'}
 
+    @resources.command
     @click.option('--detail', is_flag=True, default=False,
                   help='Print more detail.')
     def status(self, pk, detail=False, **kwargs):

--- a/tower_cli/resources/job.py
+++ b/tower_cli/resources/job.py
@@ -56,6 +56,9 @@ class Resource(models.ExeResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `job monitor` on the newly '
                        'launched job rather than exiting with a success.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Monitor the status of the job, but do not print '
+                       'while job is in progress.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '
@@ -85,8 +88,8 @@ class Resource(models.ExeResource):
     @click.option('--use-job-endpoint', required=False, default=False,
                   is_flag=True, help='A flag that disable launching jobs'
                   ' from job template when set.')
-    def launch(self, job_template=None, monitor=False, timeout=None,
-               no_input=True, extra_vars=None, **kwargs):
+    def launch(self, job_template=None, monitor=False, wait=False,
+               timeout=None, no_input=True, extra_vars=None, **kwargs):
         """Launch a new job based on a job template.
 
         Creates a new job in Ansible Tower, immediately starts it, and
@@ -233,5 +236,7 @@ class Resource(models.ExeResource):
         # monitor from here.
         if monitor:
             return self.monitor(job_id, timeout=timeout)
+        elif wait:
+            return self.wait(job_id, timeout=timeout)
 
         return result

--- a/tower_cli/resources/project.py
+++ b/tower_cli/resources/project.py
@@ -23,6 +23,7 @@ from tower_cli.utils import debug, exceptions as exc, types
 class Resource(models.Resource, models.MonitorableResource):
     cli_help = 'Manage projects within Ansible Tower.'
     endpoint = '/projects/'
+    unified_job_type = '/project_updates/'
 
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
@@ -60,8 +61,8 @@ class Resource(models.Resource, models.MonitorableResource):
                   help='If provided with --monitor, the SCM update'
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
-    def create(self, organization=None, monitor=False, timeout=None,
-               fail_on_found=False, force_on_exists=False,
+    def create(self, organization=None, monitor=False, wait=False,
+               timeout=None, fail_on_found=False, force_on_exists=False,
                **kwargs):
         """Create a new item of resource, with or w/o org.
         This would be a shared class with user, but it needs the ability
@@ -100,7 +101,9 @@ class Resource(models.Resource, models.MonitorableResource):
 
         # if the monitor flag is set, wait for the SCM to update
         if monitor and answer.get('changed', False):
-            return self.monitor(project_id, timeout=timeout)
+            return self.monitor(pk=None, parent_pk=project_id, timeout=timeout)
+        elif wait and answer.get('changed', False):
+            return self.wait(pk=None, parent_pk=project_id, timeout=timeout)
 
         return answer
 
@@ -137,7 +140,7 @@ class Resource(models.Resource, models.MonitorableResource):
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
     def update(self, pk=None, create_on_missing=False, monitor=False,
-               timeout=None, name=None, organization=None):
+               wait=False, timeout=None, name=None, organization=None):
         """Trigger a project update job within Ansible Tower.
         Only meaningful on non-manual projects.
         """
@@ -158,10 +161,13 @@ class Resource(models.Resource, models.MonitorableResource):
         # Commence the update.
         debug.log('Updating the project.', header='details')
         result = client.post('/projects/%d/update/' % pk)
+        project_update_id = result.json()['project_update']
 
         # If we were told to monitor the project update's status, do so.
         if monitor:
-            return self.monitor(pk, timeout=timeout)
+            return self.monitor(project_update_id, pk, timeout=timeout)
+        elif wait:
+            return self.wait(project_update_id, timeout=timeout)
 
         # Return the project update ID.
         return {
@@ -172,22 +178,9 @@ class Resource(models.Resource, models.MonitorableResource):
     @click.option('--detail', is_flag=True, default=False,
                   help='Print more detail.')
     def status(self, pk=None, detail=False, **kwargs):
-        """Print the current job status."""
-        # Get the job from Ansible Tower.
-        debug.log('Asking for project update status.', header='details')
-        project = client.get('/projects/%d/' % pk).json()
-
-        # Determine the appropriate project update.
-        if 'current_update' in project['related']:
-            debug.log('A current update exists; retrieving it.',
-                      header='details')
-            job = client.get(project['related']['current_update'][7:]).json()
-        elif project['related'].get('last_update', None):
-            debug.log('No current update exists; retrieving the most '
-                      'recent update.', header='details')
-            job = client.get(project['related']['last_update'][7:]).json()
-        else:
-            raise exc.NotFound('No project updates exist.')
+        """Print the status of the most recent update."""
+        # Obtain the most recent project update
+        job = self.last_job_data(pk, **kwargs)
 
         # In most cases, we probably only want to know the status of the job
         # and the amount of time elapsed. However, if we were asked for

--- a/tower_cli/resources/project.py
+++ b/tower_cli/resources/project.py
@@ -161,13 +161,15 @@ class Resource(models.Resource, models.MonitorableResource):
         # Commence the update.
         debug.log('Updating the project.', header='details')
         result = client.post('/projects/%d/update/' % pk)
-        project_update_id = result.json()['project_update']
 
         # If we were told to monitor the project update's status, do so.
         if monitor:
-            return self.monitor(project_update_id, pk, timeout=timeout)
+            project_update_id = result.json()['project_update']
+            return self.monitor(project_update_id, parent_pk=pk,
+                                timeout=timeout)
         elif wait:
-            return self.wait(project_update_id, timeout=timeout)
+            project_update_id = result.json()['project_update']
+            return self.wait(project_update_id, parent_pk=pk, timeout=timeout)
 
         # Return the project update ID.
         return {


### PR DESCRIPTION
Connect #74 

Connect #213 
## Examples of Using This Feature

Launch a job from job template number 7. Stream its standard output.

`tower-cli job launch -J 7 --monitor`

Launch that job, hold on until it finishes, but use the old wait text (which will delete itself).

`tower-cli job launch -J 7 --wait`

Print the standard out of an existing job to the command line.

`tower-cli job stdout 119`

Sync an inventory group. Stream the standard out input from the inventory module.

`tower-cli group sync --name open_stack --monitor`

Note that you can grab both `status` and `stdout` for a project. This should raise eyebrows, because technically a project doesn't have standard out (only its project update does). Actually, we grab the last job ran and show the output from that. That design decision was made a while ago, but this PR extends the logic to connect more things.

Create a project and update it. Also stream the standard out of the update.

`tower-cli project create --name="AlanCoding examples" --organization "Default" --scm-type git --scm-url https://github.com/AlanCoding/permission-testing-playbooks.git --monitor`
## Game Plans

This contains a departure from previous behavior. Anyone who uses tower-cli to connect Jenkins to Tower would be best-advised to switch from `--monitor` flags to `--wait`. On the other hand, if you like details, don't change anything.

Those above examples should also probably be converted into docs sometime and somewhere.

As a final note, this is kind of a half-way toward giving tower-cli decent abstraction for Unified Job Templates versus Unified Jobs. I foresee this being built on top of if, for instance, there was a request to incorporate a new type of Unified Job Template that also had to manage its own unique type of jobs.

Additionally, a great amount of credit goes to @chrismeyersfsu for the original prototype of this.
