### PR TITLE
allow skiping digits conversion when associating hosts to groups

### DIFF
--- a/lib/tower_cli/resources/host.py
+++ b/lib/tower_cli/resources/host.py
@@ -35,15 +35,31 @@ class Resource(models.Resource):
     @resources.command(use_fields_as_options=False)
     @click.option('--host', type=types.Related('host'))
     @click.option('--group', type=types.Related('group'))
-    def associate(self, host, group):
+    @click.option('--host-name', type=types.Related('host',
+                  convert_digits=False))
+    @click.option('--group-name', type=types.Related('group',
+                  convert_digits=False))
+    def associate(self, host, group, host_name, group_name):
         """Associate a group with this host."""
+        if host_name and not host:
+            host = host_name
+        if group_name and not group:
+            group = group_name
         return self._assoc('groups', host, group)
 
     @resources.command(use_fields_as_options=False)
     @click.option('--host', type=types.Related('host'))
     @click.option('--group', type=types.Related('group'))
-    def disassociate(self, host, group):
+    @click.option('--host-name', type=types.Related('host',
+                  convert_digits=False))
+    @click.option('--group-name', type=types.Related('group',
+                  convert_digits=False))
+    def disassociate(self, host, group, host_name, group_name):
         """Disassociate a group from this host."""
+        if host_name and not host:
+            host = host_name
+        if group_name and not group:
+            group = group_name
         return self._disassoc('groups', host, group)
 
     @resources.command(ignore_defaults=True, no_args_is_help=False)

--- a/lib/tower_cli/utils/types.py
+++ b/lib/tower_cli/utils/types.py
@@ -93,9 +93,10 @@ class Related(click.types.ParamType):
     __name__ = 'related'
     name = 'related'
 
-    def __init__(self, resource_name):
+    def __init__(self, resource_name, convert_digits=True):
         super(Related, self).__init__()
         self.resource_name = resource_name
+        self.convert_digits = convert_digits
 
     def convert(self, value, param, ctx):
         """Return the appropriate interger value. If a non-integer is
@@ -115,7 +116,7 @@ class Related(click.types.ParamType):
 
         # Do we have a string that contains only digits?
         # If so, then convert it to an integer and return it.
-        if re.match(r'^[\d]+$', value):
+        if re.match(r'^[\d]+$', value) and self.convert_digits:
             return int(value)
 
         # Special case to allow disassociations

--- a/tests/test_resources_host.py
+++ b/tests/test_resources_host.py
@@ -36,7 +36,7 @@ class HostTests(unittest.TestCase):
             t.register_json('/hosts/42/groups/?id=84',
                             {'count': 0, 'results': []})
             t.register_json('/hosts/42/groups/', {}, method='POST')
-            self.host_resource.associate(42, 84)
+            self.host_resource.associate(42, 84, None, None)
             self.assertEqual(t.requests[1].body,
                              json.dumps({'associate': True, 'id': 84}))
 
@@ -49,7 +49,7 @@ class HostTests(unittest.TestCase):
                             {'count': 1, 'results': [{'id': 84}],
                              'next': None, 'previous': None})
             t.register_json('/hosts/42/groups/', {}, method='POST')
-            self.host_resource.disassociate(42, 84)
+            self.host_resource.disassociate(42, 84, None, None)
             self.assertEqual(t.requests[1].body,
                              json.dumps({'disassociate': True, 'id': 84}))
 


### PR DESCRIPTION
It is perfectly fine to have hosts, groups and other resources to be called with an all-digits name in Tower/Ansible.
However this can confuse `tower-cli` when one tries to pass such a "name" to it.

```
% tower-cli host associate --host client123 --group 1337
Error: The Tower server claims it was sent a bad request.

POST https://192.168.121.199/api/v1/hosts/2/groups/
Params: None
Data: {"associate": true, "id": 1337}

Response: {"detail":"Group matching query does not exist."}

% tower-cli host associate --host 4713 --group foo        
Error: The requested object could not be found.
```

This PR adds a way to skip this conversion in `types.Related` which is used for the lookup of the values. And uses this new feature to implement new parameters `--host-name` and `--group-name` to `tower-cli host (dis)associate`. There are probably more places where this will be useful, but I am currently only scratching my own itch.
