### PR TITLE
Add more verbosity choices.

### DIFF
--- a/lib/tower_cli/resources/ad_hoc.py
+++ b/lib/tower_cli/resources/ad_hoc.py
@@ -59,7 +59,10 @@ class Resource(models.ExeResource):
         type=types.MappedChoice([
             (0, 'default'),
             (1, 'verbose'),
-            (2, 'debug'),
+            (2, 'more_verbose'),
+            (3, 'debug'),
+            (4, 'connection'),
+            (5, 'winrm'),
         ]),
         required=False,
     )

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -51,7 +51,10 @@ class Resource(models.Resource):
         type=types.MappedChoice([
             (0, 'default'),
             (1, 'verbose'),
-            (2, 'debug'),
+            (2, 'more_verbose'),
+            (3, 'debug'),
+            (4, 'connection'),
+            (5, 'winrm'),
         ]),
         required=False,
     )


### PR DESCRIPTION
Support additional levels of verbosity based on the options available in Tower:

* 0: Normal
* 1: Verbose
* 2: More Verbose
* 3: Debug
* 4: Connection Debug
* 5: WinRM Debug
