### PR TITLE
Include prompting for skip_tags

### DIFF
--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -26,7 +26,7 @@ from tower_cli.utils import debug, types
 from tower_cli.utils import parser
 
 
-PROMPT_LIST = ['limit', 'tags', 'job_type', 'inventory', 'credential']
+PROMPT_LIST = ['limit', 'tags', 'skip_tags', 'job_type', 'inventory', 'credential']
 
 
 class Resource(models.ExeResource):
@@ -67,6 +67,8 @@ class Resource(models.ExeResource):
                   help='Specify host limit for job template to run.')
     @click.option('--tags', required=False,
                   help='Specify tagged actions in the playbook to run.')
+    @click.option('--skip-tags', required=False,
+                  help='Specify tagged actions in the playbook to ommit.')
     @click.option('--job-type', required=False, type=click.Choice(['run',
                   'check', 'scan']), help='Specify job type for job template'
                   ' to run.')

--- a/lib/tower_cli/resources/job.py
+++ b/lib/tower_cli/resources/job.py
@@ -26,7 +26,9 @@ from tower_cli.utils import debug, types
 from tower_cli.utils import parser
 
 
-PROMPT_LIST = ['limit', 'tags', 'skip_tags', 'job_type', 'inventory', 'credential']
+PROMPT_LIST = [
+    'limit', 'tags', 'skip_tags', 'job_type', 'inventory', 'credential'
+]
 
 
 class Resource(models.ExeResource):

--- a/lib/tower_cli/resources/job_template.py
+++ b/lib/tower_cli/resources/job_template.py
@@ -70,6 +70,9 @@ class Resource(models.Resource):
     ask_tags_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for job tags on launch.')
+    ask_skip_tags_on_launch = models.Field(
+        type=bool, required=False, display=False,
+        help_text='Prompt user for tags to skip on launch.')
     ask_job_type_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for job type on launch.')


### PR DESCRIPTION
Connect #219 

Tested to the extent of making the JT and:

```
tower-cli job launch -J "Quack and Honk and prompt" --skip-tags="quack"
```

The `quack` tag gets skipped.
