### PR TITLE
Read config from environment variables.

### DIFF
--- a/docs/CONFIG_CMD_OPTIONS.md
+++ b/docs/CONFIG_CMD_OPTIONS.md
@@ -13,6 +13,7 @@
 
 ## Environment Variables
 All of the above options can also be set using environment variables. The default behavior is to allow environment variables to override your tower-cli.cfg settings, but they will not override config values that are passed in on the command line at runtime. Below is a table of the available environment variables.
+## Variable Mapping
 | *Environment Variable* | *Tower Config Key* |
 |------------------------|--------------------|
 | `TOWER_COLOR`          | `color`            |

--- a/docs/CONFIG_CMD_OPTIONS.md
+++ b/docs/CONFIG_CMD_OPTIONS.md
@@ -11,5 +11,19 @@
 | `description_on` | Boolean/'false'                                       | Whether to show description in human-formatted output.                                                                                                     |
 | `certificate`    | String/''                                             | Path to a custom certificate file that will be used throughout the command. Ignored if `--insecure` flag if set in command or `verify_ssl` is set to false |
 
+## Environment Variables
+All of the above options can also be set using environment variables. The default behavior is to allow environment variables to override your tower-cli.cfg settings, but they will not override config values that are passed in on the command line at runtime. Below is a table of the available environment variables.
+| *Environment Variable* | *Tower Config Key* |
+|------------------------|--------------------|
+| `TOWER_COLOR`          | `color`            |
+| `TOWER_FORMAT`         | `format`           |
+| `TOWER_HOST`           | `host`             |
+| `TOWER_PASSWORD`       | `password`         |
+| `TOWER_USERNAME`       | `username`         |
+| `TOWER_VERIFY_SSL`     | `verify_ssl`       |
+| `TOWER_VERBOSE`        | `verbose`          |
+| `TOWER_DESCRIPTION_ON` | `description_on`   |
+| `TOWER_CERTIFICATE`    | `certificate`      |
+
 ## Notes
 * Under the hood we use the SSL functionality of requests, however the current requests version has checkings on a deprecated SSL certificate field `commonName` (deprecated by RFC 2818). In order to prevent any related usage issues, please make sure to add `subjectAltName` field to your own certificate in use. We will update help docs as soon as changes are made on the requests side.

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -268,6 +268,7 @@ def config_from_environment(kwargs):
                 kwargs[k] = v
     return kwargs
 
+
 # The primary way to interact with settings is to simply hit the
 # already constructed settings object.
 settings = Settings()

--- a/lib/tower_cli/conf.py
+++ b/lib/tower_cli/conf.py
@@ -215,6 +215,8 @@ class Settings(object):
         """Temporarily override the runtime settings, which exist at the
         highest precedence level.
         """
+        kwargs = config_from_environment(kwargs)
+
         # Coerce all values to strings (to be coerced back by configparser
         # later) and defenestrate any None values.
         for k, v in copy.copy(kwargs).items():
@@ -250,6 +252,21 @@ class Settings(object):
             for key in kwargs:
                 self._cache.pop(k, None)
 
+
+def config_from_environment(kwargs):
+    """Read tower-cli config values from the environment if present, being
+    careful not to override config values that were explicitly passed in.
+    """
+    CONFIG_OPTIONS = ('host', 'username', 'password', 'verify_ssl', 'format',
+                      'color', 'verbose', 'description_on', 'certificate')
+    kwargs = copy.copy(kwargs)
+    for k in CONFIG_OPTIONS:
+        if k not in kwargs or kwargs[k] is None:
+            env = 'TOWER_' + k.upper()
+            v = os.getenv(env, None)
+            if v is not None:
+                kwargs[k] = v
+    return kwargs
 
 # The primary way to interact with settings is to simply hit the
 # already constructed settings object.

--- a/lib/tower_cli/resources/schedule.py
+++ b/lib/tower_cli/resources/schedule.py
@@ -126,6 +126,7 @@ class Resource(models.Resource):
                               display=False, help_text='Extra data for '
                               'schedule rules in the form of a .json file.')
 
+
 Resource.create = jt_aggregate(Resource.create, is_create=True)
 Resource.delete = jt_aggregate(Resource.delete, has_pk=True)
 Resource.get = jt_aggregate(Resource.get, has_pk=True)

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def combine_files(*args):
             file_contents.append(f.read())
     return "\n\n".join(file_contents)
 
+
 setup(
     # Basic metadata
     name='ansible-tower-cli',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -27,6 +27,7 @@ sys.path.append(APP_ROOT)
 def load_tests(loader, standard_tests, throwaway):
     return loader.discover('tests')
 
+
 # Run the tests.
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -101,3 +101,31 @@ class ParserTests(unittest.TestCase):
                                                parser.readfp)
                     read_file_method(StringIO('[general]\nfoo: bar\n'))
                     assert not warn.called
+
+
+class ConfigFromEnvironmentTests(unittest.TestCase):
+    """A set of tests that ensure the environment from config
+    parsing works as intended.
+    """
+    def test_no_override(self):
+        """Establish that the environment variables do not override explicitly
+        passed in values."""
+        settings = Settings()
+        with mock.patch.dict(os.environ, {'TOWER_HOST': 'myhost'}):
+            with settings.runtime_values(host='yourhost'):
+                self.assertEqual(settings.host, 'yourhost')
+
+    def test_read_from_env(self):
+        """Establish that the environment variables are correctly parsed
+        and the values are set in the settings."""
+        settings = Settings()
+
+        mock_env = {'TOWER_HOST': 'myhost', 'TOWER_PASSWORD': 'mypass',
+                    'TOWER_USERNAME': 'myuser', 'TOWER_VERIFY_SSL': 'False'}
+
+        with mock.patch.dict(os.environ, mock_env):
+            with settings.runtime_values():
+                self.assertEqual(settings.host, 'myhost')
+                self.assertEqual(settings.username, 'myuser')
+                self.assertEqual(settings.password, 'mypass')
+                self.assertEqual(settings.verify_ssl, False)


### PR DESCRIPTION
Provides tower-cli the ability to read config values from environment variables. If the environment variables are set, it will override the tower-cli.cfg file settings. Explicit runtime config options, `tower-cli --username ...` will override environment variables.