### PR TITLE
don't mark the inventory_script resource as internal

### DIFF
--- a/lib/tower_cli/resources/inventory_script.py
+++ b/lib/tower_cli/resources/inventory_script.py
@@ -21,7 +21,6 @@ from tower_cli.utils import types
 class Resource(models.Resource):
     cli_help = 'Manage inventory scripts within Ansible Tower.'
     endpoint = '/inventory_scripts/'
-    internal = True
 
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)


### PR DESCRIPTION
that way it shows up in help etc
the resource as such is perfectly working from the command line, no need to hide it :)