### PR TITLE
Allow custom script variables from file

### DIFF
--- a/lib/tower_cli/resources/inventory_script.py
+++ b/lib/tower_cli/resources/inventory_script.py
@@ -24,6 +24,9 @@ class Resource(models.Resource):
 
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)
-    script = models.Field(display=False)
+    script = models.Field(
+        type=types.Variables(), display=False,
+        help_text='Script code to fetch inventory, prefix with "@" to '
+                  'use contents of file for this field.')
     organization = models.Field(type=types.Related('organization'),
                                 display=False)


### PR DESCRIPTION
With recent PR, we just make this a non-abstract resource. The anticipation is that users will invoke this command directly to make custom inventory scripts. Almost all foreseeable situations will involve someone pushing a local script into Tower.

This will allow a use pattern such as

`tower-cli inventory_script create --name="example-simple-script" --script="@bash/inv_scripts/simple.py" --organization="Default"`

where the `simple.py` file contains a custom inventory script.