### PR TITLE
Add unicode support to extra_var parsing

### DIFF
--- a/tests/test_utils_parser.py
+++ b/tests/test_utils_parser.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015, Ansible, Inc.
 # Alan Rominger <arominger@ansible.com>
 #
@@ -136,6 +137,13 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(return_str, "")
         return_str = parser.process_extra_vars([""], force_json=False)
         self.assertEqual(return_str, "")
+
+    def test_handling_unicode(self):
+        """Verify that unicode strings are correctly parsed and
+        converted to desired python objects"""
+        input_unicode = u"the_user_name='äöü ÄÖÜ'"
+        return_dict = parser.string_to_dict(input_unicode)
+        self.assertEqual(return_dict, {u'the_user_name': u'äöü ÄÖÜ'})
 
 
 class TestSplitter_Gen(unittest.TestCase):

--- a/tower_cli/utils/parser.py
+++ b/tower_cli/utils/parser.py
@@ -41,13 +41,20 @@ def parse_kv(var_string):
         fix_encoding_26 = True
 
     # Also hedge against Click library giving non-string type
+    is_unicode = False
     if fix_encoding_26 or not isinstance(var_string, str):
-        var_string = str(var_string)
+        if isinstance(var_string, unicode):
+            var_string = var_string.encode('UTF-8')
+            is_unicode = True
+        else:
+            var_string = str(var_string)
 
     # Use shlex library to split string by quotes, whitespace, etc.
     for token in shlex.split(var_string):
 
         # Second part of fix to avoid passing shlex unicode in py2.6
+        if (is_unicode):
+            token = token.decode('UTF-8')
         if fix_encoding_26:
             token = six.text_type(token)
         # Look for key=value pattern, if not, process as raw parameter
@@ -141,7 +148,7 @@ def process_extra_vars(extra_vars_list, force_json=True):
                       header='decison', nl=2)
     if extra_vars == {}:
         return ""
-    return json.dumps(extra_vars)
+    return json.dumps(extra_vars, ensure_ascii=False)
 
 
 def ordered_dump(data, Dumper=yaml.Dumper, **kws):

--- a/tower_cli/utils/parser.py
+++ b/tower_cli/utils/parser.py
@@ -43,7 +43,7 @@ def parse_kv(var_string):
     # Also hedge against Click library giving non-string type
     is_unicode = False
     if fix_encoding_26 or not isinstance(var_string, str):
-        if isinstance(var_string, unicode):
+        if isinstance(var_string, six.text_type):
             var_string = var_string.encode('UTF-8')
             is_unicode = True
         else:


### PR DESCRIPTION
Connect #232.

Cause of the problem: Unicode string is hard-converted to byte string, which will lead to value overflow if the string contains non-ascii characters.

Think there are still more to be done for tower-cli internationalization. For example, `# -*- coding: utf-8 -*-` header is missing all across our code base.