### PR TITLE
Workflow job summary and monitor

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -175,13 +175,11 @@ sub-branches.
 Use the workflow_job resource to launch workflow jobs.
 This supports the use of extra_vars, which can contain answers to
 survey questions.
-A `--wait` flag is available to poll the server until workflow job
-reaches a completed status. Here is an example of using those features:
+The `--monitor` and `--wait` flag are available to poll the server
+until workflow job reaches a completed status. The `--monitor` option
+will print rolling updates of the jobs that ran as part of the workflow.
+Here is an example of using those features:
 
 ```
-tower-cli workflow_job launch -W "echo Hello World" -e a=1 --wait
+tower-cli workflow_job launch -W "echo Hello World" -e a=1 --monitor
 ```
-
-The `--wait` function will display temporary placeholder text.
-Tower-CLI does not yet offer any streaming updates of events within the
-workflow job.

--- a/tower_cli/models/fields.py
+++ b/tower_cli/models/fields.py
@@ -27,7 +27,7 @@ class Field(object):
                  display=True, filterable=True, help_text=None,
                  is_option=True, password=False, read_only=False,
                  required=True, show_default=False, unique=False,
-                 multiple=False):
+                 multiple=False, col_width=None):
         # Init the name to blank.
         # What's going on here: This is set by the ResourceMeta metaclass
         # when the **resource** is instantiated.
@@ -50,6 +50,7 @@ class Field(object):
         self.unique = unique
         self.multiple = multiple
         self.no_lookup = False
+        self.col_width = col_width
 
         # If this is a password, display is always off.
         if self.password:

--- a/tower_cli/resources/unified_job.py
+++ b/tower_cli/resources/unified_job.py
@@ -21,6 +21,8 @@ class Resource(models.Resource):
     endpoint = '/unified_jobs/'
     internal = True
 
-    status = models.Field(required=False, display=True)
-    created = models.Field(required=False, display=True)
-    elapsed = models.Field(required=False, display=True)
+    name = models.Field(required=False, display=True, col_width=24)
+    type = models.Field(required=False, display=True, col_width=14)
+    status = models.Field(required=False, display=True, col_width=10)
+    created = models.Field(required=False, display=True, col_width=24)
+    elapsed = models.Field(required=False, display=True, col_width=7)

--- a/tower_cli/resources/unified_jobs.py
+++ b/tower_cli/resources/unified_jobs.py
@@ -1,0 +1,27 @@
+# Copyright 2017, Ansible by Red Hat
+# Alan Rominger <arominge@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tower_cli import models
+
+
+class Resource(models.Resource):
+    cli_help = 'Combined model of projects, job templates, and others.'
+    endpoint = '/unified_jobs/'
+    internal = True
+
+    status = models.Field(required=False, display=True)
+    created = models.Field(required=False, display=True)
+    elapsed = models.Field(required=False, display=True)
+

--- a/tower_cli/resources/unified_jobs.py
+++ b/tower_cli/resources/unified_jobs.py
@@ -24,4 +24,3 @@ class Resource(models.Resource):
     status = models.Field(required=False, display=True)
     created = models.Field(required=False, display=True)
     elapsed = models.Field(required=False, display=True)
-

--- a/tower_cli/resources/workflow.py
+++ b/tower_cli/resources/workflow.py
@@ -28,6 +28,7 @@ import click
 class Resource(models.Resource):
     cli_help = 'Manage workflow job templates.'
     endpoint = '/workflow_job_templates/'
+    unified_job_type = '/workflow_jobs/'
 
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)

--- a/tower_cli/resources/workflow_job.py
+++ b/tower_cli/resources/workflow_job.py
@@ -58,7 +58,7 @@ class Resource(models.ExeResource):
             start_range = 0
         elif start_line > N:
             start_range = N
-        
+
         end_range = end_line
         if end_line is None or end_line > N:
             end_range = N
@@ -68,10 +68,9 @@ class Resource(models.ExeResource):
             job = jobs_list[i]
             lines.append(
                 '{0: <20} {1: <10} at {2: <20} in {3: <10} seconds'.format(
-                job['name'][:20], job['status'][:10].upper(),
-                job['finished'][:20],
-                job['elapsed']
-            ))
+                    job['name'][:20], job['status'][:10].upper(),
+                    job['finished'][:20],
+                    job['elapsed']))
         return_content = '\n'.join(lines)
         if len(lines) > 0:
             return_content += '\n'
@@ -88,14 +87,17 @@ class Resource(models.ExeResource):
         use_fields_as_options=('workflow_job_template', 'extra_vars')
     )
     @click.option('--monitor', is_flag=True, default=False,
-                  help='If sent, immediately calls monitor on the newly '
+                  help='If used, immediately calls monitor on the newly '
                        'launched workflow job rather than exiting.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Wait until completion to exit, displaying '
+                       'placeholder text while in progress.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
-    def launch(self, workflow_job_template=None, monitor=False, timeout=None,
-               extra_vars=None, **kwargs):
+    def launch(self, workflow_job_template=None, monitor=False, wait=False,
+               timeout=None, extra_vars=None, **kwargs):
         """Launch a new workflow job based on a workflow job template.
 
         Creates a new workflow job in Ansible Tower, starts it, and
@@ -114,5 +116,7 @@ class Resource(models.ExeResource):
 
         if monitor:
             return self.monitor(workflow_job_id, timeout=timeout)
+        elif wait:
+            return self.wait(workflow_job_id, timeout=timeout)
 
         return post_response


### PR DESCRIPTION
This introduces a component of workflow jobs for which I have coined the term "scorecard". This is the workflow analog to standard out. Instead of giving the Ansible standard out stream, we just list the jobs that ran as a part of the workflow. Here is the scorecard in isolation:

```
$ tower-cli workflow_job scorecard 78
Hello World goose    SUCCESSFUL at 2017-03-04T20:04:06. in 15.79      seconds
Hello World goose    SUCCESSFUL at 2017-03-04T20:04:23. in 15.787     seconds
Hello World goose    SUCCESSFUL at 2017-03-04T20:04:46. in 15.401     seconds
Hello World goose    SUCCESSFUL at 2017-03-04T20:05:03. in 15.662     seconds
Hello World goose    SUCCESSFUL at 2017-03-04T20:05:19. in 15.535     seconds

OK. (changed: false)
```

However, I really wanted to leverage this notion in order to get `--monitor` working for workflow jobs. This involved way less work than what you might expect. Here is an example of the output:

<img width="634" alt="screen shot 2017-03-04 at 3 10 24 pm" src="https://cloud.githubusercontent.com/assets/1385596/23581962/6befde94-00ed-11e7-87f4-6e4e8cb39f2d.png">

Each line appears in rolling updates as the jobs run. This does not display a complete representation of the workflow network, these simply come out in chronological order.

This PR has a bunch of extra stuff in it, because this required the work from both the standard out work and the workflow work. The standard out code hasn't been merged yet.

UPDATE: look and feel have changed, see latter comment.