### PR TITLE
Fix issue260

### DIFF
--- a/tower_cli/utils/types.py
+++ b/tower_cli/utils/types.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import, unicode_literals
 import os
 import re
+import six
 
 import click
 
@@ -49,7 +50,8 @@ class Variables(click.File):
         # Protect against corner cases of invalid inputs
         if not isinstance(value, str):
             return value
-
+        if isinstance(value, six.binary_type):
+            value = value.decode('UTF-8')
         # Read from a file under these cases
         if value.startswith('@'):
             filename = os.path.expanduser(value[1:])


### PR DESCRIPTION
Connect #260.

Note here the encoding is tacitly assumed to be utf-8. It is safe in most situations though,  considering the prevalence of utf-8 encoding nowadays.