### PR TITLE
Resolve issue256

### DIFF
--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -544,6 +544,11 @@ class ResourceMethods(BaseResource):
         # Return the response.
         return resp
 
+    def _get_patch_url(self, url, pk):
+        """Overwrite this method to handle specific corner cases to
+        the url passed to PATCH method."""
+        return url + '%s/' % pk
+
     def write(self, pk=None, create_on_missing=False, fail_on_found=False,
               force_on_exists=True, **kwargs):
         """Modify the given object using the Ansible Tower API.
@@ -635,13 +640,7 @@ class ResourceMethods(BaseResource):
         url = self.endpoint
         method = 'POST'
         if pk:
-            urlTokens = url.split('/')
-            if len(urlTokens) > 3:
-                # reconstruct url to prevent a rare corner case where resources
-                # cannot be constructed independently. Open to modification if
-                # API convention changes.
-                url = '/'.join(urlTokens[:1] + urlTokens[-2:])
-            url += '%s/' % pk
+            url = self._get_patch_url(url, pk)
             method = 'PATCH'
 
         # If debugging is on, print the URL and data being sent.

--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -635,6 +635,12 @@ class ResourceMethods(BaseResource):
         url = self.endpoint
         method = 'POST'
         if pk:
+            urlTokens = url.split('/')
+            if len(urlTokens) > 3:
+                # reconstruct url to prevent a rare corner case where resources
+                # cannot be constructed independently. Open to modification if
+                # API convention changes.
+                url = '/'.join(urlTokens[:1] + urlTokens[-2:])
             url += '%s/' % pk
             method = 'PATCH'
 

--- a/tower_cli/resources/schedule.py
+++ b/tower_cli/resources/schedule.py
@@ -126,6 +126,15 @@ class Resource(models.Resource):
                               display=False, help_text='Extra data for '
                               'schedule rules in the form of a .json file.')
 
+    def _get_patch_url(self, url, pk):
+        urlTokens = url.split('/')
+        if len(urlTokens) > 3:
+            # reconstruct url to prevent a rare corner case where resources
+            # cannot be constructed independently. Open to modification if
+            # API convention changes.
+            url = '/'.join(urlTokens[:1] + urlTokens[-2:])
+        return super(Resource, self)._get_patch_url(url, pk)
+
 
 Resource.create = jt_aggregate(Resource.create, is_create=True)
 Resource.delete = jt_aggregate(Resource.delete, has_pk=True)


### PR DESCRIPTION
Connect #256.

This issue reveals a corner case when creating a dependent resource with `--force-on-exists` on:

Suppose resource B can only be created on top of resource A (`schedule` on top of `unified job templates` in this case), The endpoint for creation is thus `/A/pkA/B/`. The modification endpoint, on the other hand, is `/B/pkB/`. A `create` method with `--force-on-exists` on converts creation to modification if the resource B exists, and the PATCH endpoints is simply concatenated into `/A/pkA/B/pkB/`, whose format is not a valid API *for now*.

The solution is dependent on API convention. Considering the possibility of further API convention changes (although highly unlikely ---- it makes little sense to have endpoints for individual related resource), the implementation here might change accordingly.