### PR TITLE
Expose --wait option for projects and groups

### DIFF
--- a/tests/test_resources_group.py
+++ b/tests/test_resources_group.py
@@ -263,8 +263,7 @@ class GroupTests(unittest.TestCase):
                     'related': {'inventory_source': '/inventory_sources/42/'},
                 }, method='GET')
                 self.gr.sync(1)
-                isrc_sync.assert_called_once_with(42, monitor=False,
-                                                  timeout=None)
+                self.assertIn((42,), isrc_sync.call_args)
                 self.assertEqual(len(t.requests), 1)
 
     def test_set_child_endpoint_id(self):

--- a/tower_cli/resources/group.py
+++ b/tower_cli/resources/group.py
@@ -249,17 +249,20 @@ class Resource(models.Resource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `monitor` on the newly '
                        'launched job rather than exiting with a success.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Polls server for status, exists when finished.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
     @resources.command(no_args_is_help=True)
-    def sync(self, group, monitor=False, timeout=None, **kwargs):
+    def sync(self, group, monitor=False, wait=False, timeout=None, **kwargs):
         """Update the given group's inventory source."""
 
         isrc = get_resource('inventory_source')
         isid = self._get_inventory_source_id(group, kwargs)
-        return isrc.update(isid, monitor=monitor, timeout=timeout, **kwargs)
+        return isrc.update(isid, monitor=monitor, timeout=timeout,
+                           wait=wait, **kwargs)
 
     @resources.command
     @click.argument('group', required=False, type=types.Related('group'))

--- a/tower_cli/resources/inventory_source.py
+++ b/tower_cli/resources/inventory_source.py
@@ -55,6 +55,8 @@ class Resource(models.MonitorableResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `monitor` on the newly '
                        'launched job rather than exiting with a success.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Polls server for status, exists when finished.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '

--- a/tower_cli/resources/project.py
+++ b/tower_cli/resources/project.py
@@ -59,6 +59,8 @@ class Resource(models.Resource, models.MonitorableResource):
                   help='If sent, immediately calls `project monitor` on the '
                        'project rather than exiting with a success.'
                        'It polls for status until the SCM is updated.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Polls server for status, exists when finished.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, the SCM update'
                        ' will time out after the given number of seconds. '
@@ -141,6 +143,8 @@ class Resource(models.Resource, models.MonitorableResource):
     @click.option('--monitor', is_flag=True, default=False,
                   help='If sent, immediately calls `job monitor` on the newly '
                        'launched job rather than exiting with a success.')
+    @click.option('--wait', is_flag=True, default=False,
+                  help='Polls server for status, exists when finished.')
     @click.option('--timeout', required=False, type=int,
                   help='If provided with --monitor, this command (not the job)'
                        ' will time out after the given number of seconds. '


### PR DESCRIPTION
In the process of testing out the master branch, I noticed this. This makes it so that commands like this work:

`tower-cli project create --name="dup2" --organization "Default" --scm-type git --scm-url https://github.com/AlanCoding/permission-testing-playbooks.git --wait`

We had it for jobs, and most of the code was already in place but they also needed to be added as options.