### PR TITLE
Change the ordering in which runtime config vars are processed

### DIFF
--- a/tests/test_utils_decorators.py
+++ b/tests/test_utils_decorators.py
@@ -15,35 +15,33 @@
 
 import click
 
-from tower_cli.utils.decorators import command
-
 from tests.compat import unittest
+
+from tower_cli.utils import decorators
 
 
 class CommandTests(unittest.TestCase):
     """Establish that the @command decorator works as I expect,
     with and without a call signature.
     """
-    def test_command_without_call_signature(self):
-        """Establish that if we call the @command decorator without a
-        call signature, that it decorates the function appropriately.
-        """
-        # Define a command.
-        @command
-        def foo():
-            pass
-
-        # Ensure that it's a command.
-        self.assertIsInstance(foo, click.core.Command)
-
     def test_command_with_call_signature(self):
-        """Establish that if we call the @command decorator with a call
+        """Establish that if we call the @click.command decorator with a call
         signature, that it decorates the function appropriately.
         """
         # Define a command
-        @command()
+        @click.command()
         def foo():
             pass
 
         # Ensure that it's a command.
         self.assertIsInstance(foo, click.core.Command)
+
+    def test_runtime_context_manager(self):
+        """Test that the kwargs from settings are removed before
+        running the command from the resource itself.
+        """
+        def foo(**kwargs):
+            self.assertEqual(kwargs, {})
+
+        foo = decorators.runtime_context_manager(foo)
+        foo(tower_username='foobear')

--- a/tower_cli/commands/version.py
+++ b/tower_cli/commands/version.py
@@ -20,12 +20,13 @@ from requests.exceptions import RequestException
 
 from tower_cli import __version__
 from tower_cli.api import client
-from tower_cli.utils.decorators import command
+from tower_cli.utils.decorators import with_global_options
 from tower_cli.utils.exceptions import TowerCLIError
 
 
-@command
-def version():
+@click.command()
+@with_global_options
+def version(**kwargs):
     """Display version information."""
 
     # Print out the current version of Tower CLI.

--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import, division, unicode_literals
+from __future__ import absolute_import, division
 
 import functools
 import inspect
@@ -39,7 +39,7 @@ from tower_cli.models.fields import Field
 from tower_cli.utils import exceptions as exc, parser, debug, secho
 from tower_cli.utils.command import Command
 from tower_cli.utils.data_structures import OrderedDict
-from tower_cli.utils.decorators import command
+from tower_cli.utils.decorators import with_global_options
 
 
 class ResourceMeta(type):
@@ -187,7 +187,7 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
 
                 # Wrap the method, such that it outputs its final return
                 # value rather than returning it.
-                new_method = self._echo_method(method)
+                new_method = with_global_options(self._echo_method(method))
 
                 # Soft copy the "__click_params__", if any exist.
                 # This is the internal holding method that the click library
@@ -246,12 +246,14 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                             help=option_help,
                             type=field.type,
                             show_default=field.show_default,
-                            multiple=field.multiple
+                            multiple=field.multiple,
+                            is_eager=False
                         )(new_method)
 
                 # Make a click Command instance using this method
                 # as the callback, and return it.
-                cmd = command(name=name, cls=Command, **attrs)(new_method)
+                cmd = click.command(name=name, cls=Command, **attrs)(
+                    new_method)
 
                 # If this method has a `pk` positional argument,
                 # then add a click argument for it.


### PR DESCRIPTION
This is an extremely aggressive change, which gets rid of an old multi-purpose decorator (which was confusingly named "command", like many other command decorators), and moves one of its functions (the application of runtime parameters) into a callback method. Also relies on `is_eager`.

One shortcoming might be the removal of the contextmanager, which could mean that the values are "sticky" from one operation to another if used in a python context. I think the right solution going from there would be to just do some post-action hook of nuking the runtime config parser.

This should resolve a lot of reported issues simultaneously, so I'm not going to go about listing them all just yet. But there are some serious release planning considerations, and I want to give @wenottingham an idea that, no, this is not at all a simple fix, and merging this will cary substantial risks of unforeseen bugs, although the bug this resolves is likewise rather severe.

We probably want to exclude this for 3.1.0. I won't be able to do the necessary followup work (you can bet some tests will fail) until after next week. I'd vote to ship this this in a quick 3.1.1.

For the record, this problem also looks like it has existed for the vast majority of the history of tower-cli.