### PR TITLE
Use safer format indicator across base.py

### DIFF
--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -692,7 +692,7 @@ class ResourceMethods(BaseResource):
         # If it turns out the record doesn't exist, handle the 404
         # appropriately (this is an okay response if `fail_on_missing` is
         # False).
-        url = '%s%d/' % (self.endpoint, pk)
+        url = '%s%s/' % (self.endpoint, pk)
         debug.log('DELETE %s' % url, fg='blue', bold=True)
         try:
             client.delete(url)
@@ -889,7 +889,7 @@ class MonitorableResource(ResourceMethods):
         Internal utility function to return standard out
         requires the pk of a unified job
         """
-        stdout_url = '%s%d/stdout/' % (self.unified_job_type, pk)
+        stdout_url = '%s%s/stdout/' % (self.unified_job_type, pk)
         payload = {
             'format': 'json', 'content_encoding': 'base64',
             'content_format': 'ansi'}
@@ -1143,7 +1143,7 @@ class ExeResource(MonitorableResource):
         # Get the job from Ansible Tower if pk given
         else:
             debug.log('Asking for job status.', header='details')
-            finished_endpoint = '%s%d/' % (self.endpoint, pk)
+            finished_endpoint = '%s%s/' % (self.endpoint, pk)
             job = client.get(finished_endpoint).json()
 
         # In most cases, we probably only want to know the status of the job
@@ -1173,7 +1173,7 @@ class ExeResource(MonitorableResource):
             existing_data = self.get(**kwargs)
             pk = existing_data['id']
 
-        cancel_endpoint = '%s%d/cancel/' % (self.endpoint, pk)
+        cancel_endpoint = '%s%s/cancel/' % (self.endpoint, pk)
         # Attempt to cancel the job.
         try:
             client.post(cancel_endpoint)


### PR DESCRIPTION
connect #269.

It's terrifying to think such a bug has been lurking in base.py for so long: [Our `pk` argument is initialized as a string](https://github.com/ansible/tower-cli/blob/master/tower_cli/models/base.py#L263), yet `%d` is used to represent `pk` across various places in base.py. It is okay if `pk` is substituted by a real integer beforehand, but will cause traceback if it keeps what it is.

A safer way is substituting `%s` over `%d`, which accepts integer types as well. Guess the initial purpose of using `%d` is for type check, but a server-side error is way better than a traceback *_*