### PR TITLE
Get packages to install locally again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@
 import re
 import sys
 from distutils.core import setup
+from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 
 
@@ -130,9 +131,7 @@ setup(
     scripts=[
         'bin/tower-cli',
     ],
-    packages=[
-        'tower_cli',
-    ],
+    packages=find_packages(exclude=['tests']),
     # How to do the tests
     tests_require=['tox'],
     cmdclass={'test': Tox},


### PR DESCRIPTION
We have seen an error doing a local install (`make install`) that gave this kind of traceback:

```
$ tower-cli inventory create
Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/cli2/bin/tower-cli", line 4, in <module>
    __import__('pkg_resources').run_script('ansible-tower-cli==3.2.0', 'tower-cli')
  File "/Users/alancoding/.virtualenvs/cli2/lib/python2.7/site-packages/pkg_resources/__init__.py", line 738, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/Users/alancoding/.virtualenvs/cli2/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1499, in run_script
    exec(code, namespace, namespace)
  File "/Users/alancoding/.virtualenvs/cli2/lib/python2.7/site-packages/ansible_tower_cli-3.2.0-py2.7.egg/EGG-INFO/scripts/tower-cli", line 25, in <module>
    from tower_cli.utils import secho
ImportError: No module named utils
```

It is believed that this is fallout from recent packaging changes, where the `utils` directory needs to be listed as a package itself. We know that the "packages" list was changed to _only_ show tower-cli, but it looks like this won't work with the imports we use in the build process at a minimum. So this still accomplishes the objective of not including the tests, but includes utils and others.