### PR TITLE
name changed from foreman to satellite6 in tower 3.1.x

### DIFF
--- a/tower_cli/resources/credential.py
+++ b/tower_cli/resources/credential.py
@@ -53,9 +53,9 @@ class Resource(models.Resource):
         display=True,
         help_text='The type of credential being added. '
                   'Valid options are: ssh, net, scm, aws, rax, vmware,'
-                  ' foreman, cloudforms, gce, azure, azure_rm, openstack.',
+                  ' satellite6, cloudforms, gce, azure, azure_rm, openstack.',
         type=click.Choice(['ssh', 'net', 'scm', 'aws', 'rax', 'vmware',
-                           'foreman', 'cloudforms', 'gce', 'azure',
+                           'satellite6', 'cloudforms', 'gce', 'azure',
                            'azure_rm', 'openstack']),
     )
 


### PR DESCRIPTION
Latest tower-cli should be updated with satellite6 instead of foreman (broken in Tower CLI 3.1.3)