### PR TITLE
Abandon `object_pairs_hook` as a json loads arg at exception

### DIFF
--- a/tower_cli/api.py
+++ b/tower_cli/api.py
@@ -227,7 +227,11 @@ class APIResponse(Response):
     """
     def json(self, **kwargs):
         kwargs.setdefault('object_pairs_hook', data_structures.OrderedDict)
-        return super(APIResponse, self).json(**kwargs)
+        try:
+            return super(APIResponse, self).json(**kwargs)
+        except Exception:
+            kwargs.pop('object_pairs_hook', None)
+            return super(APIResponse, self).json(**kwargs)
 
 
 client = Client()


### PR DESCRIPTION
Connect #281. 

Some (not all, 2.6.9 is an exception, for example) python 2.6 minor versions do not support `object_pairs_hook` as a json loads argument. Use a retry mechanism ensures robustness.