### PR TITLE
Fixing spelling errors

### DIFF
--- a/tower_cli/resources/ad_hoc.py
+++ b/tower_cli/resources/ad_hoc.py
@@ -85,7 +85,7 @@ class Resource(models.ExeResource):
                        ' will time out after the given number of seconds. '
                        'Does nothing if --monitor is not sent.')
     @click.option('--become', required=False, is_flag=True,
-                  help='If used, privledge escalation will be enabled for '
+                  help='If used, privilege escalation will be enabled for '
                        'this command.')
     def launch(self, monitor=False, wait=False, timeout=None, become=False,
                **kwargs):

--- a/tower_cli/resources/credential.py
+++ b/tower_cli/resources/credential.py
@@ -127,10 +127,10 @@ class Resource(models.Resource):
         required=False, display=False,
     )
 
-    # Method with which to esclate
+    # Method with which to escalate
     become_method = models.Field(
         display=False,
-        help_text='Privledge escalation method. ',
+        help_text='Privilege escalation method. ',
         type=types.MappedChoice([
             ('', 'None'),
             ('sudo', 'sudo'),


### PR DESCRIPTION
A couple of fixed spelling errors I noticed when running with `--help`.