### PR TITLE
allow specification of hipchat rooms

### DIFF
--- a/tower_cli/resources/notification_template.py
+++ b/tower_cli/resources/notification_template.py
@@ -124,6 +124,11 @@ class Resource(models.Resource):
                                             'gray', 'random']),
                          help_text='[{0}]The notification color.'.
                          format('hipchat'))
+    rooms = models.Field(required=False, display=False, default=False,
+                         help_text='[{0}]Rooms to send notification to. '
+                         'Use multiple flags to send to multiple rooms, ex '
+                         '--rooms=A --rooms=B'.
+                         format('hipchat'), multiple=True)
     notify = models.Field(required=False, display=False, default=False,
                           help_text='[{0}]The notify channel trigger.'.
                           format('hipchat'))


### PR DESCRIPTION
Connect #299 

The help text:

```
  --rooms TEXT                    [hipchat]Rooms to send notification to. Use
                                  multiple flags to multiple rooms, ex
                                  --rooms=A --rooms=B
```

Demo:

```
tower-cli notification_template create --name 'test' --description 'test' --organization 'Default' --notification-type 'hipchat' --message-from 'XXX' --api-url 'XXX' --color gray --token 'XXX' --rooms 'Testing' -v
*** DETAILS: The organization field is given as a name; looking it up. ********
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v1/organizations/
Params: {'name': 'Default'}

*** DETAILS: Checking for an existing record. *********************************
GET http://localhost:8013/api/v1/notification_templates/
Params: {'name': u'test'}

*** DETAILS: Writing the record. **********************************************
PATCH http://localhost:8013/api/v1/notification_templates/1/
Data: {'organization': 1, 'notification_configuration': {'message_from': u'XXX', 'api_url': u'XXX', 'color': 'gray', 'token': u'XXX', 'rooms': (u'Testing',), 'notify': False}, 'description': u'test', 'name': u'test', 'notification_type': 'hipchat'}

Resource changed.
== ==== ================= 
id name notification_type 
== ==== ================= 
 1 test hipchat
== ==== ================= 
```

Result:

![screen shot 2017-07-06 at 12 01 36 pm](https://user-images.githubusercontent.com/1385596/27920597-1f50a462-6243-11e7-9f63-3bdb38870bf6.png)
