### PR TITLE
Allow related specification of inv src by short name

### DIFF
--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -162,3 +162,17 @@ class StatusTests(unittest.TestCase):
             })
             with self.assertRaises(exc.NotFound):
                 self.res.status(1)
+
+
+class NameTests(unittest.TestCase):
+
+    def setUp(self):
+        self.res = tower_cli.get_resource('inventory_source')
+
+    def test_valid_name(self):
+        assert self.res._is_full_v1_name('foo bar (In Space - 873928)')
+
+    def test_invalid_names(self):
+        assert not self.res._is_full_v1_name('foo bar (In Space  873928)')
+        assert not self.res._is_full_v1_name('foo bar (In Space - 873928')
+        assert not self.res._is_full_v1_name('foo bar (In Space - )')

--- a/tower_cli/resources/inventory_source.py
+++ b/tower_cli/resources/inventory_source.py
@@ -19,6 +19,8 @@ from tower_cli import models, resources
 from tower_cli.api import client
 from tower_cli.utils import debug, types, exceptions as exc
 
+import re
+
 
 class Resource(models.MonitorableResource):
     cli_help = 'Manage inventory sources within Ansible Tower.'
@@ -26,6 +28,7 @@ class Resource(models.MonitorableResource):
     internal = True
     unified_job_type = '/inventory_updates/'
 
+    name = models.Field(unique=True)
     credential = models.Field(type=types.Related('credential'), required=False)
     source = models.Field(
         default=None,
@@ -40,7 +43,7 @@ class Resource(models.MonitorableResource):
     instance_filters = models.Field(required=False, display=False)
     group_by = models.Field(required=False, display=False)
     source_script = models.Field(type=types.Related('inventory_script'),
-                                 required=False)
+                                 required=False, display=False)
     # Boolean variables
     overwrite = models.Field(type=bool, required=False, display=False)
     overwrite_vars = models.Field(type=bool, required=False, display=False)
@@ -50,6 +53,9 @@ class Resource(models.MonitorableResource):
                                         display=False)
     timeout = models.Field(type=int, required=False, display=False,
                            help_text='The timeout field (in seconds).')
+
+    def _is_full_v1_name(self, name):
+        return bool(re.match(r'^.+\s\(.+\s-\s\d+\)$', name))
 
     @click.argument('inventory_source', type=types.Related('inventory_source'))
     @click.option('--monitor', is_flag=True, default=False,

--- a/tower_cli/utils/types.py
+++ b/tower_cli/utils/types.py
@@ -135,7 +135,15 @@ class Related(click.types.ParamType):
         try:
             debug.log('The %s field is given as a name; '
                       'looking it up.' % param.name, header='details')
-            rel = resource.get(**{resource.identity[-1]: value})
+            lookup_data = {resource.identity[-1]: value}
+            # Special case to look up inventory sources by partial name
+            # TODO: Remove with v1 deprecation
+            if (self.resource_name == 'inventory_source' and
+                    not resource._is_full_v1_name(value)):
+                lookup_data = {
+                    "query": [('name__startswith', value)]
+                }
+            rel = resource.get(**lookup_data)
         except exc.MultipleResults as ex:
             raise exc.MultipleRelatedError(
                 'Cannot look up {0} exclusively by name, because multiple {0} '


### PR DESCRIPTION
This is a shot at #302

However, I'm not 100% sure this will be workable. The extremely major problem is that group names are not unique globally, and that's what this is leveraging. But if this solves an immediate need, it might be acceptable.

Demo:

```
tower-cli node create -W asdf --inventory-source "Alan AWS" -v
*** DETAILS: The workflow_job_template field is given as a name; looking it up. 
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v1/workflow_job_templates/
Params: {'name': 'asdf'}

*** DETAILS: The inventory_source field is given as a name; looking it up. ****
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v1/inventory_sources/
Params: {u'name__startswith': 'Alan AWS'}

*** DETAILS: Checking for an existing record. *********************************
*** DETAILS: Writing the record. **********************************************
POST http://localhost:8013/api/v1/workflow_job_template_nodes/
Data: {'unified_job_template': 10, 'workflow_job_template': 25}

Resource changed.
== ===================== ==================== 
id workflow_job_template unified_job_template 
== ===================== ==================== 
 1                    25                   10
== ===================== ==================== 
```

Note that the workflow schema is fully built on top of these existing utilities, so when you reference something in the workflow schema command, it's doing the same thing as here.