### PR TITLE
Categorize help text options

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,4 +16,4 @@ exclude_lines =
 
     # Don't complain about missing debug-only code:
     def __repr__
-
+show_missing = True

--- a/tests/test_cli_action.py
+++ b/tests/test_cli_action.py
@@ -21,6 +21,22 @@ from tower_cli.cli.action import ActionSubcommand
 from tests.compat import unittest
 
 
+CATEGORIZED_OUTPUT = """Usage: foo [OPTIONS]
+
+Field Options:
+  --bar TEXT  foobar
+
+Local Options:
+  --foo TEXT  foobar
+
+Global Options:
+  --tower-host TEXT  foobar
+
+Other Options:
+  --help  Show this message and exit.
+"""
+
+
 class ActionCommandTests(unittest.TestCase):
     """A set of tests to ensure that the tower_cli Command class works
     in the way we expect.
@@ -45,3 +61,23 @@ class ActionCommandTests(unittest.TestCase):
         result = self.runner.invoke(foo)
         self.assertIn('--help', result.output)
         self.assertIn('Show this message and exit.\n', result.output)
+
+    def test_categorize_options(self):
+        """Establish that options in help text are correctly categorized.
+        """
+        @click.command(cls=ActionSubcommand)
+        @click.option('--foo', help='foobar')
+        @click.option('--bar', help='[FIELD]foobar')
+        @click.option('--tower-host', help='foobar')
+        def foo():
+            pass
+
+        result = self.runner.invoke(foo)
+        self.assertEqual(result.output, CATEGORIZED_OUTPUT)
+
+        @click.command(cls=ActionSubcommand, add_help_option=False)
+        def bar():
+            pass
+
+        result = self.runner.invoke(bar)
+        self.assertEqual(result.output, 'Usage: bar [OPTIONS]\n')

--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -164,6 +164,19 @@ class SubcommandTests(unittest.TestCase):
         self.assertEqual(opt.name, 'internal_name')
         self.assertEqual(opt.opts, ['--option-name'])
 
+    def test_field_help_text_has_prefix(self):
+        """Establish that resource field help text is properly prefixed.
+        """
+        class FieldHelpTextResource(models.Resource):
+            endpoint = '/foobar/'
+
+            option_name = models.Field('internal_name', help_text='foobar', required=False)
+
+        cmd = ResSubcommand(FieldHelpTextResource()).get_command(None, 'get')
+
+        opt = cmd.params[0]
+        self.assertEqual(opt.help, '[FIELD]foobar')
+
     def test_docstring_replacement_an(self):
         """Establish that for resources with names beginning with vowels,
         that the automatic docstring replacement is gramatically correct.

--- a/tower_cli/cli/action.py
+++ b/tower_cli/cli/action.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 import click
+from click.formatting import join_options
+
+from tower_cli.conf import SETTINGS_PARMS
 
 
 class ActionSubcommand(click.Command):
@@ -41,3 +44,42 @@ class ActionSubcommand(click.Command):
             click.echo(ctx.get_help())
             ctx.exit()
         return super(ActionSubcommand, self).parse_args(ctx, args)
+
+    def format_options(self, ctx, formatter):
+        """Monkey-patch click's format_options method to support option categorization.
+        """
+        field_opts = []
+        global_opts = []
+        local_opts = []
+        other_opts = []
+        for param in self.params:
+            if param.name in SETTINGS_PARMS:
+                opts = global_opts
+            elif getattr(param, 'help', None) and param.help.startswith('[FIELD]'):
+                opts = field_opts
+                param.help = param.help[len('[FIELD]'):]
+            else:
+                opts = local_opts
+            rv = param.get_help_record(ctx)
+            if rv is None:
+                continue
+            else:
+                opts.append(rv)
+
+        if self.add_help_option:
+            help_options = self.get_help_option_names(ctx)
+            if help_options:
+                other_opts.append([join_options(help_options)[0], 'Show this message and exit.'])
+
+        if field_opts:
+            with formatter.section('Field Options'):
+                formatter.write_dl(field_opts)
+        if local_opts:
+            with formatter.section('Local Options'):
+                formatter.write_dl(local_opts)
+        if global_opts:
+            with formatter.section('Global Options'):
+                formatter.write_dl(global_opts)
+        if other_opts:
+            with formatter.section('Other Options'):
+                formatter.write_dl(other_opts)

--- a/tower_cli/cli/resource.py
+++ b/tower_cli/cli/resource.py
@@ -187,8 +187,7 @@ class ResSubcommand(click.MultiCommand):
         for col in columns:
             widths[col] = max(
                 len(col),
-                *[len(six.text_type(i.get(col, 'N/A')))
-                  for i in raw_rows]
+                *[len(six.text_type(i.get(col, 'N/A'))) for i in raw_rows]
             )
             fd = fields_by_name.get(col, None)
             if fd is not None and fd.col_width is not None:
@@ -327,10 +326,10 @@ class ResSubcommand(click.MultiCommand):
                 option_help = field.help
                 if field.required:
                     option_help = '[REQUIRED] ' + option_help
+                option_help = '[FIELD]' + option_help
                 click.option(
                     *args,
-                    default=field.default if not ignore_defaults
-                    else None,
+                    default=field.default if not ignore_defaults else None,
                     help=option_help,
                     type=field.type,
                     show_default=field.show_default,
@@ -340,15 +339,13 @@ class ResSubcommand(click.MultiCommand):
 
         # Make a click Command instance using this method
         # as the callback, and return it.
-        cmd = click.command(name=name, cls=ActionSubcommand, **attrs)(
-            new_method)
+        cmd = click.command(name=name, cls=ActionSubcommand, **attrs)(new_method)
 
         # If this method has a `pk` positional argument,
         # then add a click argument for it.
         code = six.get_function_code(method)
         if 'pk' in code.co_varnames:
-            click.argument('pk', nargs=1, required=False,
-                           type=str, metavar='[ID]')(cmd)
+            click.argument('pk', nargs=1, required=False, type=str, metavar='[ID]')(cmd)
 
         # Done; return the command.
         return cmd


### PR DESCRIPTION
This PR increases readability of action command help text by categorizing options into 4 categories.

1. 'Field Options', which are options derived from resource fields.
2. 'Local Options', which are custom options specific to individual action commands.
3. 'Global Options', which are options that control runtime settings keyword arguments.
4. 'Other Options', which includes and only includes `--help` for now.