### PR TITLE
allow for multiple inheritances with click methods

### DIFF
--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -90,8 +90,46 @@ class ResourceMetaTests(unittest.TestCase):
 
         # Establish that it has one of the options added to the
         # superclass list command.
-        self.assertTrue(any([i.name == 'query'
-                            for i in MyResource.list.__click_params__]))
+        self.assertEqual(MyResource.list.__click_params__, models.Resource.list.__click_params__)
+
+    def test_multiple_inheritance(self):
+        """
+        Establish that click decoration from all parent class chains are
+        preserved in a subclass.
+        """
+        class MyMixin(models.Resource):
+            endpoint = '/bogus/'
+
+            def list(self, **kwargs):
+                return super(MyMixin, self).list(**kwargs)
+
+        class MyResource(MyMixin, models.Resource):
+            endpoint = '/bogus/'
+
+            def list(self, **kwargs):
+                return super(MyResource, self).list(**kwargs)
+
+        self.assertTrue(hasattr(MyResource.list, '__click_params__'))
+        self.assertEqual(MyResource.list.__click_params__, models.Resource.list.__click_params__)
+
+    def test_no_duplicate_options_from_inheritance(self):
+        """
+        Test that metaclass does not duplicate options from multiple parents
+        """
+        class MyMixin1(models.Resource):
+            endpoint = '/bogus/'
+
+        class MyMixin2(models.Resource):
+            endpoint = '/boguser/'
+
+        class MyResource(MyMixin1, MyMixin2):
+            endpoint = '/boguser/'
+
+            def list(self, **kwargs):
+                return super(MyResource, self).list(**kwargs)
+
+        self.assertTrue(hasattr(MyResource.list, '__click_params__'))
+        self.assertEqual(MyResource.list.__click_params__, models.Resource.list.__click_params__)
 
     def test_fields(self):
         """Establish that fields are appropriately classified within

--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -63,18 +63,34 @@ class ResourceMeta(type):
             # down to the subclass implementation.
             if not len(bases):
                 continue
-            superclass = bases[0]
-            super_method = getattr(superclass, key, None)
-            if super_method and getattr(super_method, '_cli_command', False):
-                # Copy the click parameters from the parent method to the
-                # child.
-                cp = getattr(value, '__click_params__', [])
-                cp = getattr(super_method, '__click_params__', []) + cp
-                value.__click_params__ = cp
+            cp = []
+            baseattrs = {}
+            for superclass in bases:
+                super_method = getattr(superclass, key, None)
+                if super_method and getattr(super_method, '_cli_command', False):
+                    # Copy the click parameters from the parent method to the
+                    # child.
+                    for param in getattr(super_method, '__click_params__', []):
+                        if param not in cp:
+                            cp.append(param)
 
-                # Copy the command attributes from the parent to the child,
-                # if the child has not overridden them.
-                for attkey, attval in super_method._cli_command_attrs.items():
+                    # Copy the command attributes from the parent to the child,
+                    # if the child has not overridden them.
+                    for attkey, attval in getattr(super_method, '_cli_command_attrs', {}).items():
+                        baseattrs.setdefault(attkey, attval)
+            if cp:
+                # If subclass method is not decorated as command, but parent
+                # classes do, then make it into a command here
+                if not hasattr(value, '__click_params__'):
+                    value.__click_params__ = []
+                if not hasattr(value, '_cli_command_attrs'):
+                    value._cli_command_attrs = {}
+
+                # Copy all parent click parameters to subclass method here
+                for param in cp:
+                    if param not in value.__click_params__:
+                        value.__click_params__.append(param)
+                for attkey, attval in baseattrs.items():
                     value._cli_command_attrs.setdefault(attkey, attval)
         attrs['commands'] = sorted(commands)
 


### PR DESCRIPTION
This has caused bugs in the past. I hope the test is expressive enough to show what is being solved.

Basically, we previously couldn't use mixins, because the click decoration would not be respected across multiple parent classes (see the naive `superclass = bases[0]`), which means that almost any attempt at using multiple classes would result in missing or incomplete commands.

Note that python functionality was never impacted. That was never really a problem. This deals with `@command(**kwargs)` in parent classes, mixins, and subclasses - how to choose which kwargs and other args to use and such.