### PR TITLE
	Prevent travis testing for python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"


### PR DESCRIPTION
The latest version of wheel drops the support for python 2.6, and it is
tricky to force tox to install a non-latest version of wheel in the
context of travis. So we remove 2.6 tests from travis, also as a first
step towards dropping python 2.6 support.