### PR TITLE
remove old version logic not needed in v2 API

### DIFF
--- a/tests/test_resources_credential.py
+++ b/tests/test_resources_credential.py
@@ -73,12 +73,11 @@ class CredentialTests(unittest.TestCase):
             self.assertTrue(cred_res.fields[3].no_lookup)
 
             # Verify request data is correct
-            self.assertEqual(len(t.requests), 3)
-            self.assertEqual(t.requests[0].method, 'OPTIONS')
-            self.assertEqual(t.requests[1].method, 'GET')
-            self.assertEqual(t.requests[2].method, 'POST')
-            self.assertTrue('name=foobar' in t.requests[1].url)
+            self.assertEqual(len(t.requests), 2)
+            self.assertEqual(t.requests[0].method, 'GET')
+            self.assertEqual(t.requests[1].method, 'POST')
+            self.assertIn('name=foobar', t.requests[0].url)
             # Make sure special fields not used for GET
-            self.assertTrue('user' not in t.requests[1].url)
+            self.assertTrue('user' not in t.requests[0].url)
             # Make sure special files are used in actual POST
-            self.assertTrue('user' in t.requests[2].body)
+            self.assertIn('user', t.requests[1].body)

--- a/tower_cli/models/fields.py
+++ b/tower_cli/models/fields.py
@@ -27,7 +27,7 @@ class Field(object):
                  display=True, filterable=True, help_text=None,
                  is_option=True, password=False, read_only=False,
                  required=True, show_default=False, unique=False,
-                 multiple=False, col_width=None):
+                 multiple=False, no_lookup=False, col_width=None):
         # Init the name to blank.
         # What's going on here: This is set by the ResourceMeta metaclass
         # when the **resource** is instantiated.
@@ -49,7 +49,7 @@ class Field(object):
         self.show_default = show_default
         self.unique = unique
         self.multiple = multiple
-        self.no_lookup = False
+        self.no_lookup = no_lookup
         self.col_width = col_width
 
         # If this is a password, display is always off.

--- a/tower_cli/resources/credential.py
+++ b/tower_cli/resources/credential.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tower_cli import models, resources
-from tower_cli.utils import debug
-from tower_cli.api import client
+from tower_cli import models
 from tower_cli.cli import types
 
 
@@ -29,47 +27,9 @@ class Resource(models.Resource):
     description = models.Field(required=False, display=False)
 
     # Who owns this credential?
-    user = models.Field(display=False, type=types.Related('user'), required=False)
-    team = models.Field(display=False, type=types.Related('team'), required=False)
+    user = models.Field(display=False, type=types.Related('user'), required=False, no_lookup=True)
+    team = models.Field(display=False, type=types.Related('team'), required=False, no_lookup=True)
     organization = models.Field(display=False, type=types.Related('organization'), required=False)
 
     credential_type = models.Field(type=types.Related('credential_type'))
     inputs = models.Field(type=types.StructuredInput(), required=False, display=False)
-
-    @resources.command
-    def create(self, **kwargs):
-        """Create a credential.
-
-        Fields in the resource's `identity` tuple are used for a lookup;
-        if a match is found, then no-op (unless `force_on_exists` is set) but
-        do not fail (unless `fail_on_found` is set).
-
-        =====API DOCS=====
-        Create a credential.
-
-        :param fail_on_found: Flag that if set, the operation fails if an object matching the unique criteria
-                              already exists.
-        :type fail_on_found: bool
-        :param force_on_exists: Flag that if set, then if a match is found on unique fields, other fields will
-                                be updated to the provided values.; If unset, a match causes the request to be
-                                a no-op.
-        :type force_on_exists: bool
-        :param `**kwargs`: Keyword arguements which, all together, will be used as POST body to create the
-                           resource object.
-        :returns: A dictionary combining the JSON output of the created resource, as well as two extra fields:
-                  "changed", a flag indicating if the resource is created successfully; "id", an integer which
-                  is the primary key of the created object.
-        :rtype: dict
-
-
-        =====API DOCS=====
-        """
-        if (kwargs.get('user', False) or kwargs.get('team', False) or
-                kwargs.get('organization', False)):
-            debug.log('Checking Project API Details.', header='details')
-            r = client.options('/credentials/')
-            if 'organization' in r.json()['actions']['POST']:
-                for i in range(len(self.fields)):
-                    if self.fields[i].name in ('user', 'team'):
-                        self.fields[i].no_lookup = True
-        return super(Resource, self).create(**kwargs)


### PR DESCRIPTION
Resolves #358

Some basic demoing:

```
$ tower-cli credential create --credential-type="Source Control" --inputs='{"username": "asdf", "password": "fdsa"}' --user=admin --name='asdf' -v
*** DETAILS: The credential_type field is given as a name; looking it up. *****
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v2/credential_types/
Params: {'name': 'Source Control'}

*** DETAILS: The user field is given as a name; looking it up. ****************
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v2/users/
Params: {'username': 'admin'}

*** DETAILS: Checking for an existing record. *********************************
GET http://localhost:8013/api/v2/credentials/
Params: {'name': u'asdf'}

*** DETAILS: Writing the record. **********************************************
POST http://localhost:8013/api/v2/credentials/
Data: {'inputs': {'username': 'asdf', 'password': 'fdsa'}, 'credential_type': 2, 'user': 1, 'name': u'asdf'}

Resource changed.
== ==== =============== 
id name credential_type 
== ==== =============== 
 8 asdf               2
== ==== =============== 
```

We might have some other bugs to file - it's not using credential type in the lookup, not providing name doesn't raise an error right away.