### PR TITLE
add instance group association commands

### DIFF
--- a/tower_cli/resources/inventory.py
+++ b/tower_cli/resources/inventory.py
@@ -48,3 +48,44 @@ class Resource(models.Resource):
         return client.post(url, data={}).json()
 
     batch_update.format_freezer = 'json'
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--inventory', type=types.Related('inventory'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def associate_ig(self, inventory, instance_group):
+        """Associate an instance group with this inventory.
+        The instance group will be used to run jobs within the inventory.
+
+        =====API DOCS=====
+        Associate an instance group with this inventory.
+
+        :param inventory: Primary key or name of the inventory to associate to.
+        :type inventory: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._assoc('instance_groups', inventory, instance_group)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--inventory', type=types.Related('inventory'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def disassociate_ig(self, inventory, instance_group):
+        """Disassociate an instance group from this inventory.
+
+        =====API DOCS=====
+        Disassociate an instance group with this inventory.
+
+        :param inventory: Primary key or name of the inventory to associate to.
+        :type inventory: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._disassoc('instance_groups', inventory, instance_group)

--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -276,3 +276,44 @@ class Resource(models.SurveyResource):
         r = client.post(url, data=post_data, auth=None)
         if r.status_code == 201:
             return {'changed': True}
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--job-template', type=types.Related('job_template'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def associate_ig(self, job_template, instance_group):
+        """Associate an instance group with this job_template.
+        The instance group will be used to run jobs within the job_template.
+
+        =====API DOCS=====
+        Associate an instance group with this job_template.
+
+        :param job_template: Primary key or name of the job_template to associate to.
+        :type job_template: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._assoc('instance_groups', job_template, instance_group)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--job-template', type=types.Related('job_template'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def disassociate_ig(self, job_template, instance_group):
+        """Disassociate an instance group from this job_template.
+
+        =====API DOCS=====
+        Disassociate an instance group with this job_template.
+
+        :param job_template: Primary key or name of the job_template to associate to.
+        :type job_template: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._disassoc('instance_groups', job_template, instance_group)

--- a/tower_cli/resources/organization.py
+++ b/tower_cli/resources/organization.py
@@ -110,3 +110,44 @@ class Resource(models.Resource):
         =====API DOCS=====
         """
         return self._disassoc('admins', organization, user)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--organization', type=types.Related('organization'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def associate_ig(self, organization, instance_group):
+        """Associate an instance group with this organization.
+        The instance group will be used to run jobs within the organization.
+
+        =====API DOCS=====
+        Associate an instance group with this organization.
+
+        :param organization: Primary key or name of the organization to associate to.
+        :type organization: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._assoc('instance_groups', organization, instance_group)
+
+    @resources.command(use_fields_as_options=False)
+    @click.option('--organization', type=types.Related('organization'), required=True)
+    @click.option('--instance-group', type=types.Related('instance_group'), required=True)
+    def disassociate_ig(self, organization, instance_group):
+        """Disassociate an instance group from this organization.
+
+        =====API DOCS=====
+        Disassociate an instance group with this organization.
+
+        :param organization: Primary key or name of the organization to associate to.
+        :type organization: str
+        :param instance_group: Primary key or name of the instance group to be associated.
+        :type instance_group: str
+        :returns: Dictionary of only one key "changed", which indicates whether the association succeeded.
+        :rtype: dict
+
+        =====API DOCS=====
+        """
+        return self._disassoc('instance_groups', organization, instance_group)


### PR DESCRIPTION
Connect https://github.com/ansible/tower-cli/issues/376

Since the command name would have been so long, I named this `associate_ig`.

General functional testing works fine.

```
(cli2)arominge-OSX:tower-cli alancoding$ tower-cli organization
Usage: tower-cli organization [OPTIONS] COMMAND [ARGS]...

  Manage organizations within Ansible Tower.

Options:
  --help  Show this message and exit.

Commands:
  associate           Associate a user with this organization.
  associate_admin     Associate an admin with this organization.
  associate_ig        Associate an instance group with this...
  copy                Copy an organization.
  create              Create an organization.
  delete              Remove the given organization.
  disassociate        Disassociate a user from this organization.
  disassociate_admin  Disassociate an admin from this organization.
  disassociate_ig     Disassociate an instance group from this...
  get                 Return one and exactly one organization.
  list                Return a list of organizations.
  modify              Modify an already existing organization.
(cli2)arominge-OSX:tower-cli alancoding$ tower-cli inventory
Usage: tower-cli inventory [OPTIONS] COMMAND [ARGS]...

  Manage inventory within Ansible Tower.

Options:
  --help  Show this message and exit.

Commands:
  associate_ig     Associate an instance group with this...
  batch_update     Update all related inventory sources of the...
  copy             Copy an inventory.
  create           Create an inventory.
  delete           Remove the given inventory.
  disassociate_ig  Disassociate an instance group from this...
  get              Return one and exactly one inventory.
  list             Return a list of inventories.
  modify           Modify an already existing inventory.
(cli2)arominge-OSX:tower-cli alancoding$ tower-cli job_template
Usage: tower-cli job_template [OPTIONS] COMMAND [ARGS]...

  Manage job templates.

Options:
  --help  Show this message and exit.

Commands:
  associate_credential            Associate a credential with this job...
  associate_ig                    Associate an instance group with this...
  associate_label                 Associate an label with this job template.
  associate_notification_template
                                  Associate a notification template from
                                  this...
  callback                        Contact Tower and request a configuration...
  copy                            Copy a job template.
  create                          Create a job template.
  delete                          Remove the given job template.
  disassociate_credential         Disassociate a credential with this job...
  disassociate_ig                 Disassociate an instance group from this...
  disassociate_label              Disassociate an label from this job
                                  template.
  disassociate_notification_template
                                  Disassociate a notification template from...
  get                             Return one and exactly one job template.
  list                            Return a list of job templates.
  modify                          Modify an already existing job template.
  survey                          Get the survey_spec for the job template.
```