### PR TITLE
Audit changes needed in 3.2 for job resources

### DIFF
--- a/tests/test_resources_ad_hoc.py
+++ b/tests/test_resources_ad_hoc.py
@@ -46,7 +46,7 @@ class LaunchTests(unittest.TestCase):
             self.assertEqual(result, {'changed': True, 'id': 42})
 
     def test_launch_with_become(self):
-        """Establish that we are able use the --become flag
+        """Establish that we are able use the --become-enabled flag
         """
         with client.test_mode as t:
             t.register_json('/ad_hoc_commands/42/', {'id': 42}, method='GET')
@@ -54,11 +54,7 @@ class LaunchTests(unittest.TestCase):
                 'ad_hoc_commands': '/api/%s/ad_hoc_commands/' % CUR_API_VERSION
                 }, method='GET')
             t.register_json('/ad_hoc_commands/', {'id': 42}, method='POST')
-            self.res.launch(inventory="foobar", machine_credential=2,
-                            become=True)
-            # Critically, we test that the request sent to the server
-            # contains the key "become_enabled", as this must be triggered
-            # by the conditional written specifically for --become
+            self.res.launch(inventory="foobar", machine_credential=2, become_enabled=True)
             self.assertDictContainsSubset(
                 {'become_enabled': True},
                 json.loads(t.requests[1].body)

--- a/tower_cli/resources/job.py
+++ b/tower_cli/resources/job.py
@@ -25,9 +25,7 @@ from tower_cli.cli import types
 from tower_cli.utils import debug, parser
 
 
-PROMPT_LIST = [
-    'limit', 'tags', 'skip_tags', 'job_type', 'inventory', 'credential'
-]
+PROMPT_LIST = ['diff_mode', 'limit', 'tags', 'skip_tags', 'job_type', 'verbosity', 'inventory', 'credential']
 
 
 class Resource(models.ExeResource):
@@ -67,23 +65,17 @@ class Resource(models.ExeResource):
     @click.option('-e', '--extra-vars', required=False, multiple=True,
                   help='yaml format text that contains extra variables '
                        'to pass on. Use @ to get these from a file.')
-    @click.option('--limit', required=False,
-                  help='Specify host limit for job template to run.')
-    @click.option('--tags', required=False,
-                  help='Specify tagged actions in the playbook to run.')
-    @click.option('--skip-tags', required=False,
-                  help='Specify tagged actions in the playbook to ommit.')
-    @click.option('--job-type', required=False, type=click.Choice(['run',
-                  'check']), help='Specify job type for job template'
-                  ' to run.')
-    @click.option(
-        '--inventory', required=False, type=types.Related('inventory'),
-        help='Specify inventory for job template to run.'
-    )
-    @click.option(
-        '--credential', required=False, type=types.Related('credential'),
-        help='Specify machine credential for job template to run.'
-    )
+    @click.option('--diff-mode', type=bool, required=False, help='Specify diff mode for job template to run.')
+    @click.option('--limit', required=False, help='Specify host limit for job template to run.')
+    @click.option('--tags', required=False, help='Specify tagged actions in the playbook to run.')
+    @click.option('--skip-tags', required=False, help='Specify tagged actions in the playbook to ommit.')
+    @click.option('--job-type', required=False, type=click.Choice(['run', 'check']),
+                  help='Specify job type for job template to run.')
+    @click.option('--verbosity', type=int, required=False, help='Specify verbosity of the playbook run.')
+    @click.option('--inventory', required=False, type=types.Related('inventory'),
+                  help='Specify inventory for job template to run.')
+    @click.option('--credential', required=False, type=types.Related('credential'),
+                  help='Specify machine credential for job template to run.')
     def launch(self, job_template=None, monitor=False, wait=False,
                timeout=None, no_input=True, extra_vars=None, **kwargs):
         """Launch a new job based on a job template.
@@ -108,6 +100,8 @@ class Resource(models.ExeResource):
         :type no_input: bool
         :param extra_vars: yaml formatted texts that contains extra variables to pass on.
         :type extra_vars: array of strings
+        :param diff_mode: Specify diff mode for job template to run.
+        :type diff_mode: bool
         :param limit: Specify host limit for job template to run.
         :type limit: str
         :param tags: Specify tagged actions in the playbook to run.
@@ -115,7 +109,9 @@ class Resource(models.ExeResource):
         :param skip_tags: Specify tagged actions in the playbook to ommit.
         :type skip_tags: str
         :param job_type: Specify job type for job template to run.
-        :type job_type str
+        :type job_type: str
+        :param verbosity: Specify verbosity of the playbook run.
+        :type verbosity: int
         :param inventory: Specify machine credential for job template to run.
         :type inventory: str
         :param credential: Specify machine credential for job template to run.

--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -38,15 +38,8 @@ class Resource(models.SurveyResource):
     inventory = models.Field(type=types.Related('inventory'), required=False)
     project = models.Field(type=types.Related('project'))
     playbook = models.Field()
-    machine_credential = models.Field(
-        'credential',
-        display=False, required=False,
-        type=types.Related('credential'),
-    )
-    cloud_credential = models.Field(type=types.Related('credential'),
-                                    required=False, display=False)
-    network_credential = models.Field(type=types.Related('credential'),
-                                      required=False, display=False)
+    credential = models.Field(display=False, required=False, type=types.Related('credential'))
+    vault_credential = models.Field(type=types.Related('credential'), required=False, display=False)
     forks = models.Field(type=int, required=False, display=False)
     limit = models.Field(required=False, display=False)
     verbosity = models.Field(
@@ -61,15 +54,25 @@ class Resource(models.SurveyResource):
         ]),
         required=False,
     )
+    extra_vars = models.Field(type=types.Variables(), required=False, display=False, multiple=True,
+                              help_text='Extra variables used by Ansible in YAML or key=value '
+                                        'format. Use @ to get YAML from a file.')
     job_tags = models.Field(required=False, display=False)
+    force_handlers = models.Field(type=bool, required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
-    extra_vars = models.Field(
-        type=types.Variables(), required=False, display=False, multiple=True,
-        help_text='Extra variables used by Ansible in YAML or key=value '
-                  'format. Use @ to get YAML from a file.')
+    start_at_task = models.Field(required=False, display=False)
+    timeout = models.Field(type=int, required=False, display=False,
+                           help_text='The amount of time (in seconds) to run before the task is canceled.')
+    use_fact_cache = models.Field(type=bool, required=False, display=False,
+                                  help_text='If enabled, Tower will act as an Ansible Fact Cache Plugin;'
+                                            ' persisting facts at the end of a playbook run to the database'
+                                            ' and caching facts for use by Ansible.')
     host_config_key = models.Field(
         required=False, display=False,
         help_text='Allow Provisioning Callbacks using this host config key')
+    ask_diff_mode_on_launch = models.Field(
+        type=bool, required=False, display=False,
+        help_text='Ask diff mode on launch.')
     ask_variables_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for extra_vars on launch.')
@@ -85,19 +88,24 @@ class Resource(models.SurveyResource):
     ask_job_type_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for job type on launch.')
+    ask_verbosity_on_launch = models.Field(
+        type=bool, required=False, display=False,
+        help_text='Prompt user for verbosity on launch.')
     ask_inventory_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for inventory on launch.')
     ask_credential_on_launch = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for machine credential on launch.')
-    become_enabled = models.Field(type=bool, required=False, display=False)
-    allow_simultaneous = models.Field(type=bool, required=False, display=False)
-    timeout = models.Field(type=int, required=False, display=False,
-                           help_text='The timeout field (in seconds).')
     survey_enabled = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for job type on launch.')
+    become_enabled = models.Field(type=bool, required=False, display=False)
+    diff_mode = models.Field(type=bool, required=False, display=False,
+                             help_text='If enabled, textual changes made to any templated files on'
+                                       ' the host are shown in the standard output.')
+    allow_simultaneous = models.Field(type=bool, required=False, display=False)
+
     survey_spec = models.Field(
         type=types.Variables(), required=False, display=False,
         help_text='On write commands, perform extra POST to the '

--- a/tower_cli/resources/workflow.py
+++ b/tower_cli/resources/workflow.py
@@ -168,6 +168,7 @@ class Resource(models.SurveyResource):
     survey_enabled = models.Field(
         type=bool, required=False, display=False,
         help_text='Prompt user for job type on launch.')
+    allow_simultaneous = models.Field(type=bool, required=False, display=False)
     survey_spec = models.Field(
         type=types.Variables(), required=False, display=False,
         help_text='On write commands, perform extra POST to the '


### PR DESCRIPTION
Audit against OPTIONS return of Tower 3.2 and make up any missing fields
for resources job_template, job, workflow and ad_hoc_command.

Signed-off-by: Aaron Tan <jangsutsr@gmail.com>