### PR TITLE
add resources for project/inv updates

### DIFF
--- a/tests/test_resources_inventory_source.py
+++ b/tests/test_resources_inventory_source.py
@@ -46,7 +46,7 @@ class UpdateTests(unittest.TestCase):
             t.register_json('/inventory_sources/1/update/',
                             {'can_update': True}, method='GET')
             t.register_json('/inventory_sources/1/update/',
-                            {}, method='POST')
+                            {'inventory_update': 42}, method='POST')
             answer = self.isr.update(1)
             self.assertEqual(answer['status'], 'ok')
 

--- a/tests/test_resources_project.py
+++ b/tests/test_resources_project.py
@@ -172,7 +172,7 @@ class UpdateTests(unittest.TestCase):
             t.register_json('/projects/1/update/', {'project_update': 42},
                             method='POST')
             result = self.res.update(1)
-            self.assertEqual(result, {'changed': True})
+            self.assertEqual(result, {'changed': True, 'id': 42})
 
     def test_basic_update_with_monitor(self):
         """Establish that we are able to create a project update

--- a/tower_cli/constants.py
+++ b/tower_cli/constants.py
@@ -14,3 +14,18 @@
 
 
 CUR_API_VERSION = 'v2'
+
+LAUNCH_TYPE_CHOICES = [
+    'manual', 'relaunch', 'relaunch', 'callback',
+    'scheduled', 'dependency', 'workflow', 'sync', 'scm'
+]
+
+STATUS_CHOICES = [
+    'new', 'pending', 'waiting', 'running', 'successful',
+    'failed', 'error', 'canceled'
+]
+
+INVENTORY_SOURCE_CHOICES = [
+    '', 'file', 'scm', 'ec2', 'vmware', 'gce', 'azure', 'azure_rm', 'openstack',
+    'satellite6', 'cloudforms', 'custom'
+]

--- a/tower_cli/resources/inventory_update.py
+++ b/tower_cli/resources/inventory_update.py
@@ -1,0 +1,46 @@
+# Copyright 2017, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, unicode_literals
+
+import click
+
+from tower_cli import models
+from tower_cli.constants import LAUNCH_TYPE_CHOICES, STATUS_CHOICES, INVENTORY_SOURCE_CHOICES
+from tower_cli.cli import types
+
+
+class Resource(models.ExeResource):
+    """A resource for inventory source updates.
+    """
+    cli_help = 'Launch or monitor inventory source updates.'
+    endpoint = '/inventory_updates/'
+
+    inventory_source = models.Field(
+        key='-I',
+        type=types.Related('inventory_source'), required=True, display=True
+    )
+    name = models.Field(required=False, display=True, read_only=True)
+    launch_type = models.Field(
+        type=click.Choice(LAUNCH_TYPE_CHOICES), read_only=True, display=True
+    )
+    status = models.Field(
+        type=click.Choice(STATUS_CHOICES), read_only=True
+    )
+    job_explanation = models.Field(required=False, display=False, read_only=True)
+    created = models.Field(required=False, display=True, read_only=True)
+    elapsed = models.Field(required=False, display=True, read_only=True)
+    source = models.Field(
+        type=click.Choice(INVENTORY_SOURCE_CHOICES), display=True
+    )

--- a/tower_cli/resources/project.py
+++ b/tower_cli/resources/project.py
@@ -248,17 +248,18 @@ class Resource(models.Resource, models.MonitorableResource):
         debug.log('Updating the project.', header='details')
         result = client.post('/projects/%d/update/' % pk)
 
+        project_update_id = result.json()['project_update']
+
         # If we were told to monitor the project update's status, do so.
         if monitor:
-            project_update_id = result.json()['project_update']
             return self.monitor(project_update_id, parent_pk=pk,
                                 timeout=timeout)
         elif wait:
-            project_update_id = result.json()['project_update']
             return self.wait(project_update_id, parent_pk=pk, timeout=timeout)
 
         # Return the project update ID.
         return {
+            'id': project_update_id,
             'changed': True,
         }
 

--- a/tower_cli/resources/project_update.py
+++ b/tower_cli/resources/project_update.py
@@ -1,0 +1,55 @@
+# Copyright 2017, Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, unicode_literals
+
+import click
+
+from tower_cli import models
+from tower_cli.constants import LAUNCH_TYPE_CHOICES, STATUS_CHOICES
+from tower_cli.cli import types
+
+
+class Resource(models.ExeResource):
+    """A resource for project updates.
+    """
+    cli_help = 'Launch or monitor project updates.'
+    endpoint = '/project_updates/'
+
+    project = models.Field(
+        key='-P',
+        type=types.Related('project'), required=True, display=True
+    )
+    name = models.Field(required=False, display=True, read_only=True)
+    launch_type = models.Field(
+        type=click.Choice(LAUNCH_TYPE_CHOICES), read_only=True, display=False
+    )
+    status = models.Field(
+        type=click.Choice(STATUS_CHOICES), read_only=True
+    )
+    job_type = models.Field(
+        type=click.Choice(['run', 'check']), read_only=True
+    )
+    job_explanation = models.Field(required=False, display=False, read_only=True)
+    created = models.Field(required=False, display=True, read_only=True)
+    elapsed = models.Field(required=False, display=True, read_only=True)
+    scm_type = models.Field(
+        type=types.MappedChoice([
+            ('', 'manual'),
+            ('git', 'git'),
+            ('hg', 'hg'),
+            ('svn', 'svn'),
+            ('insights', 'insights'),
+        ]), display=False
+    )


### PR DESCRIPTION
Connect #343

This isn't perfect, but it will help a lot.

I've tested this with the stdout, delete, and cancel commands. Before, we had no access to these, and all of the logic already works.

I also changed how we are returning responses for basic project and inventory updates. For job launches we return the id, so I want to be consistent with that. But of course, launching a job from the job command has a congruency that launching from the template does not. So it's still weird, but we should be returning the job id on every launch as a best-possible practice.