### PR TITLE
Handle extra-long words in printing debug log

### DIFF
--- a/tests/test_utils_debug.py
+++ b/tests/test_utils_debug.py
@@ -63,16 +63,25 @@ class LogTests(unittest.TestCase):
         """
         s = ' '.join(['multi-line'] * 30)
         expected = '\n'.join([
-            '*** DETAILS: multi-line multi-line multi-line '
-            'multi-line multi-line multi-line ',
-            '*** multi-line multi-line multi-line multi-line '
-            'multi-line multi-line *********',
-            '*** multi-line multi-line multi-line multi-line '
-            'multi-line multi-line *********',
-            '*** multi-line multi-line multi-line multi-line '
-            'multi-line multi-line *********',
-            '*** multi-line multi-line multi-line multi-line '
-            'multi-line multi-line *********',
+            '*** DETAILS: multi-line multi-line multi-line multi-line multi-line multi-line ',
+            '*** multi-line multi-line multi-line multi-line multi-line multi-line *********',
+            '*** multi-line multi-line multi-line multi-line multi-line multi-line *********',
+            '*** multi-line multi-line multi-line multi-line multi-line multi-line *********',
+            '*** multi-line multi-line multi-line multi-line multi-line multi-line *********',
+        ])
+        with mock.patch.object(click, 'secho') as secho:
+            with settings.runtime_values(verbose=True):
+                debug.log(s, header='details')
+            self.assertEqual(secho.mock_calls[0][1][0], expected)
+
+    def test_extra_long_words(self):
+        """Ensure we treat words longer than 79 characters properly and do not
+        trigger any issue.
+        """
+        s = ' '.join(['short_word', 'short_word', 'l' + 'o' * 68 + 'ng_word'])
+        expected = '\n'.join([
+            '*** DETAILS: short_word short_word ********************************************',
+            '*** loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_word ',
         ])
         with mock.patch.object(click, 'secho') as secho:
             with settings.runtime_values(verbose=True):

--- a/tower_cli/utils/debug.py
+++ b/tower_cli/utils/debug.py
@@ -45,6 +45,10 @@ def log(s, header='', file=sys.stderr, nl=1, **kwargs):
                     i += 1
                     if i == len(word_arr):
                         break
+            # Handle corner case of extra-long word longer than 75 characters.
+            if len(to_add) == 1:
+                to_add.append(word_arr[i])
+                i += 1
             if i != len(word_arr):
                 count -= len(word_arr[i]) + 1
             to_add.append('*' * (78 - count))


### PR DESCRIPTION
Relates #389.

The initial implementation does not take into consideration that some
words in a debug log might be longer than 75 characters, thus cause
infinite loop.