### PR TITLE
make combine_files() work with UTF-8 encoded files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 import re
 import sys
+import codecs
 from distutils.core import setup
 from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
@@ -108,7 +109,7 @@ def combine_files(*args):
     with two line breaks between them"""
     file_contents = []
     for filename in args:
-        with open(filename, 'r') as f:
+        with codecs.open(filename, mode='r', encoding='utf8') as f:
             file_contents.append(f.read())
     return "\n\n".join(file_contents)
 


### PR DESCRIPTION
setup.py might fail on Python 3 in non-UTF8 environments while parsing
HISTORY.rst or README.rst which are not required to be ASCII-only with:

    UnicodeDecodeError: 'ascii' codec can't decode …

We could also require the files to be plain ASCII, but it sounds not the
right thing to do in the 21st century.

Simple reproducer:

    % LC_ALL=C python3 setup.py
    Traceback (most recent call last):
      File "setup.py", line 126, in <module>
        long_description=combine_files('README.rst', 'HISTORY.rst'),
      File "setup.py", line 112, in combine_files
        file_contents.append(f.read())
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2132: ordinal not in range(128)