### PR TITLE
New awx-cli entry point and setup.py refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,13 @@ $(foreach DIST, $(DISTS), $(eval $(call RPM_DIST_RULE,$(DIST))))
 
 all: $(RPMS)
 
-clean:
+remove_complied:
+	find . -type d -name "__pycache__" -delete
+	find . -name '*.pyc' -delete
+
+clean: remove_complied
 	rm -rf dist
+	rm -rf build
 	rm -rf ansible_tower_cli.egg-info
 	rm -rf rpm-build
 
@@ -44,25 +49,23 @@ rpm-build/.exists:
 
 # For devel convenience
 install:
-	sudo rm -rf dist/ build/ 
-	sudo python setup.py install
+	python setup.py install
+
+refresh: clean install
 
 clean_v2:
 	rm -rf tower_cli_v2
 	rm -rf ansible_tower_cli_v2.egg-info
 	rm -rf setup_v2.py
-	rm -f bin/tower-cli-v2
 
 setup_v2.py:
 	cp -R tower_cli tower_cli_v2/
-	cp bin/tower-cli bin/tower-cli-v2
 	cp setup.py setup_v2.py
 	python version_swap.py
 
 prep_v2: setup_v2.py
 
 install_v2: setup_v2.py
-	sudo rm -rf dist/ build/
-	sudo python setup_v2.py install
+	python setup_v2.py install
 
-v2-refresh: clean_v2 install_v2
+v2-refresh: clean clean_v2 install_v2

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ from setuptools.command.test import test as TestCommand
 
 
 pkg_name = 'tower_cli'
+dashed_name = pkg_name.replace('_', '-')
+awx_entry = dashed_name.replace('tower', 'awx')
 
 
 class Tox(TestCommand):
@@ -116,14 +118,14 @@ def combine_files(*args):
 
 setup(
     # Basic metadata
-    name='ansible-%s' % pkg_name.replace('_', '-'),
-    version=open('tower_cli/VERSION').read().strip(),
-    author='Luke Sneeringer',
-    author_email='lsneeringer@ansible.com',
+    name='ansible-%s' % dashed_name,
+    version=open('%s/VERSION' % pkg_name).read().strip(),
+    author='Red Hat, Inc.',
+    author_email='info@ansible.com',
     url='https://github.com/ansible/tower-cli',
 
     # Additional information
-    description='A CLI tool for Ansible Tower.',
+    description='A CLI tool for Ansible Tower and AWX.',
     long_description=combine_files('README.rst', 'HISTORY.rst'),
     license='Apache 2.0',
 
@@ -132,10 +134,14 @@ setup(
     provides=[
         pkg_name,
     ],
-    scripts=[
-        'bin/%s' % pkg_name.replace('_', '-'),
-    ],
+    entry_points={
+        'console_scripts': [
+            '%s=%s.cli.run:cli' % (dashed_name, pkg_name),
+            '%s=%s.cli.run:cli' % (awx_entry, pkg_name),
+        ],
+    },
     packages=find_packages(exclude=['tests']),
+    include_package_data=True,
     # How to do the tests
     tests_require=['tox'],
     cmdclass={'test': Tox},
@@ -155,11 +161,11 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: System :: Software Distribution',
         'Topic :: System :: Systems Administration',
     ],

--- a/tower_cli/cli/run.py
+++ b/tower_cli/cli/run.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# Copyright 2013-2014, Ansible, Inc.
-# Luke Sneeringer <lsneeringer@ansible.com>
+# Copyright 2013-2017, Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,9 +17,7 @@ import click
 from tower_cli.cli.base import TowerCLI
 
 
-if __name__ == '__main__':
-    cli = TowerCLI(
-        params=[click.Option(param_decls=['--version'], is_flag=True,
-                             help='Display tower-cli version.')],
-    )
-    cli()
+cli = TowerCLI(
+    params=[click.Option(param_decls=['--version'], is_flag=True,
+                         help='Display tower-cli version.')],
+)

--- a/version_swap.py
+++ b/version_swap.py
@@ -14,16 +14,16 @@ def convert_file(filename):
             'Command has already ran, no need to run again.' % filename
         )
     s = s.replace('tower_cli', package_name)
-    s = s.replace('tower-cli', 'tower-cli-v%s' % API_VERSION)
     with open(filename, "w") as f:
         f.write(s)
 
 
+# Conversion of secondary source tree
 for dname, dirs, files in os.walk(package_name):
     for fname in files:
         fpath = os.path.join(dname, fname)
         convert_file(fpath)
 
 
+# Conversion of seconary setup file
 convert_file('setup_v%s.py' % API_VERSION)
-convert_file('bin/tower-cli-v%s' % API_VERSION)


### PR DESCRIPTION
Switch from using scripts in setuptools to entry_point
Add a new entry_point "awx-cli" which functions the same as tower-cli
Need for sudo has been eliminated for normal install method

---
I tested this through installing `awx-cli-v2`, and nothing is the matter with that. It's a little confusing that `awx-cli` shares credentials with `tower-cli`, but different from `tower-cli-v2` and `awx-cli-v2`, but it's probably not all that difficult.

With the removal of sudo, I this is a _huge_ improvement, and kudos to @ryanpetrello for shining the light on the right way to do this.