### PR TITLE
improve version command, detect AWX

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@
 include LICENSE
 include README.rst
 include HISTORY.rst
-include VERSION
 include tower_cli/VERSION
 include requirements.txt
 recursive-include docs *

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -25,6 +25,7 @@ import tower_cli
 from tower_cli.api import client
 from tower_cli.cli.misc import config, version, _echo_setting
 from tower_cli.conf import settings
+from tower_cli.constants import CUR_API_VERSION
 
 from tests.compat import unittest, mock
 
@@ -43,14 +44,26 @@ class VersionTests(unittest.TestCase):
         # Set up output from the /config/ endpoint in Tower and
         # invoke the command.
         with client.test_mode as t:
-            t.register_json('/config/', {'version': '4.21'})
+            t.register_json('/config/', {
+                'license_info': {
+                    'license_type': 'open'
+                },
+                'version': '4.21',
+                'ansible_version': '2.7'
+            })
             result = self.runner.invoke(version)
 
             # Verify that we got the output we expected.
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(
                 result.output.strip(),
-                'Tower CLI %s\nAnsible Tower 4.21' % tower_cli.__version__,
+                'Tower CLI %s\n'
+                'API %s\n'
+                'AWX 4.21\n'
+                'Ansible 2.7' % (
+                    tower_cli.__version__,
+                    CUR_API_VERSION
+                ),
             )
 
     def test_cannot_connect(self):

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -25,6 +25,7 @@ from tower_cli import __version__, exceptions as exc
 from tower_cli.api import client
 from tower_cli.conf import with_global_options, Parser, settings
 from tower_cli.utils import secho
+from tower_cli.constants import CUR_API_VERSION
 
 __all__ = ['version', 'config']
 
@@ -32,19 +33,31 @@ __all__ = ['version', 'config']
 @click.command()
 @with_global_options
 def version(**kwargs):
-    """Display version information."""
+    """Display full version information."""
 
     # Print out the current version of Tower CLI.
     click.echo('Tower CLI %s' % __version__)
+
+    # Print out the current API version of the current code base.
+    click.echo('API %s' % CUR_API_VERSION)
 
     # Attempt to connect to the Ansible Tower server.
     # If we succeed, print a version; if not, generate a failure.
     try:
         r = client.get('/config/')
-        click.echo('Ansible Tower %s' % r.json()['version'])
     except RequestException as ex:
         raise exc.TowerCLIError('Could not connect to Ansible Tower.\n%s' %
                                 six.text_type(ex))
+    config = r.json()
+    license = config.get('license_info', {}).get('license_type', 'open')
+    if license == 'open':
+        server_type = 'AWX'
+    else:
+        server_type = 'Ansible Tower'
+    click.echo('%s %s' % (server_type, config['version']))
+
+    # Print out Ansible version of server
+    click.echo('Ansible %s' % config['ansible_version'])
 
 
 def _echo_setting(key):


### PR DESCRIPTION
This gives a little more elaboration to the version command, and auto-detects the type of license, and stubs in AWX if it is the "open" kind.

for AWX:

```
$ tower-cli version
Tower CLI 3.2.0
AWX 1.0.1-31-g353a9a5
Ansible version 2.3.2.0
```

for an actual Tower server:

```
$ tower-cli version
Tower CLI 3.2.0
Ansible Tower 3.2.0
Ansible version 2.3.0.0
```