### PR TITLE
make CUR_API_VERSION importable in v1 branch

### DIFF
--- a/tower_cli/constants.py
+++ b/tower_cli/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2017, Ansible by Red Hat.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+CUR_API_VERSION = 'v1'


### PR DESCRIPTION
replaces #372 