### PR TITLE
[WIP] explicitly declare package to be zip_safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,4 +173,5 @@ setup(
         'Topic :: System :: Software Distribution',
         'Topic :: System :: Systems Administration',
     ],
+    zip_safe=True
 )


### PR DESCRIPTION
The install is slightly faster, about 0.7s vs 0.9s with the flag True. I haven't tested the command times.

We might also need to have a special debug mode, if this won't give descriptive tracebacks, but not sure. Needs testing.