### PR TITLE
always read settings from environment

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -112,25 +112,23 @@ class ConfigFromEnvironmentTests(unittest.TestCase):
     def test_no_override(self):
         """Establish that the environment variables do not override explicitly
         passed in values."""
-        settings = Settings()
         with mock.patch.dict(os.environ, {'TOWER_HOST': 'myhost'}):
+            settings = Settings()
             with settings.runtime_values(host='yourhost'):
                 self.assertEqual(settings.host, 'yourhost')
 
     def test_read_from_env(self):
         """Establish that the environment variables are correctly parsed
         and the values are set in the settings."""
-        settings = Settings()
-
         mock_env = {'TOWER_HOST': 'myhost', 'TOWER_PASSWORD': 'mypass',
                     'TOWER_USERNAME': 'myuser', 'TOWER_VERIFY_SSL': 'False'}
 
         with mock.patch.dict(os.environ, mock_env):
-            with settings.runtime_values():
-                self.assertEqual(settings.host, 'myhost')
-                self.assertEqual(settings.username, 'myuser')
-                self.assertEqual(settings.password, 'mypass')
-                self.assertEqual(settings.verify_ssl, False)
+            settings = Settings()
+            self.assertEqual(settings.host, 'myhost')
+            self.assertEqual(settings.username, 'myuser')
+            self.assertEqual(settings.password, 'mypass')
+            self.assertEqual(settings.verify_ssl, False)
 
 
 class CommandTests(unittest.TestCase):

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -113,6 +113,7 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
         seen = set()
         parser_desc = {
             'runtime': 'Runtime options.',
+            'environment': 'Options from environment variables.',
             'local': 'Local options (set with `tower-cli config '
                      '--scope=local`; stored in .tower_cli.cfg of this '
                      'directory or a parent)',


### PR DESCRIPTION
Connect #296 

```
$ TOWER_HOST=foo.invalid tower-cli user list
Error: There was a network error of some kind trying to connect to Tower.

The most common  reason for this is a settings issue; is your "host" value in `tower-cli config` correct?
Right now it is: "foo.invalid".
```