### PR TITLE
fix package discovery bug in v2 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,20 @@ pkg_name = 'tower_cli'
 dashed_name = pkg_name.replace('_', '-')
 
 
+# Avoid packaging any other API version of tower-cli with current one
+exclude_list = ['tests']
+primary_install = len(pkg_name.split('_')) == 2
+base_name = pkg_name[:9]
+if not primary_install:
+    exclude_list += [base_name, '{}.*'.format(base_name)]
+for v in (1, 2):
+    if pkg_name.endswith(str(v)):
+        continue
+    v_name = '{}_v{}'.format(base_name, v)
+    exclude_list += [v_name, '{}.*'.format(v_name)]
+discovered_packages = find_packages(exclude=exclude_list)
+
+
 class Tox(TestCommand):
     """The test command should install and then run tox.
 
@@ -146,7 +160,8 @@ setup(
             '%s=%s.cli.run:cli' % (dashed_name, pkg_name),
         ],
     },
-    packages=find_packages(exclude=['tests']),
+    packages=discovered_packages,
+    include_package_data=True,
     # How to do the tests
     tests_require=['tox'],
     cmdclass={'test': Tox},


### PR DESCRIPTION
What package discovery looks like for the v1 install now:

```
['tower_cli_v1', 'tower_cli_v1.cli', 'tower_cli_v1.models', 'tower_cli_v1.resources', 'tower_cli_v1.utils']
```

This did get ugly, sorry about that. Did not anticipate this problem in the beginning.

Addresses https://github.com/ansible/tower-cli/issues/428