### PR TITLE
cleaner handling of unicode

### DIFF
--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -11,11 +11,6 @@ from tower_cli.conf import settings
 
 from tests.compat import unittest, mock
 
-try:
-    basestring
-except NameError:
-    basestring = None
-
 
 class SubcommandTests(unittest.TestCase):
     """A set of tests for establishing that the Subcommand class created
@@ -297,7 +292,7 @@ class SubcommandTests(unittest.TestCase):
         self.assertIn('2 Austin, TX', output)
 
     def test_unicode_human_formatting(self):
-        value = 'unicode ❤ ☀ ☆ ☂'
+        value = u'unicode ❤ ☀ ☆ ☂'
         data = {
             'count': 1,
             'results': [
@@ -308,11 +303,7 @@ class SubcommandTests(unittest.TestCase):
                 }
             ]
         }
-        if basestring:
-            # Python < 3
-            data['results'][1]['name'] = value.decode('utf-8')
-        else:
-            data['results'][1]['name'] = value
+        data['results'][1]['name'] = value
         output = self.command._format_human(data)
         assert value in output
 

--- a/tower_cli/cli/resource.py
+++ b/tower_cli/cli/resource.py
@@ -32,11 +32,6 @@ from tower_cli.cli.action import ActionSubcommand
 from tower_cli.exceptions import MultipleRelatedError
 from tower_cli.cli.types import StructuredInput
 
-try:
-    basestring
-except NameError:
-    basestring = None
-
 
 class ResSubcommand(click.MultiCommand):
     """A subcommand that implements all command methods on the
@@ -154,9 +149,7 @@ class ResSubcommand(click.MultiCommand):
     def get_print_value(data, col):
         value = data.get(col, 'N/A')
         is_bool = isinstance(value, bool)
-        if basestring and isinstance(value, basestring) and type(value) is not str:
-            value = value.encode('utf-8')  # handle python 2 encoding problem
-        value = '%s' % value
+        value = six.text_type(value)
         if is_bool:
             value = value.lower()
         return value
@@ -250,7 +243,7 @@ class ResSubcommand(click.MultiCommand):
         for raw_row in raw_rows:
             data_row = ''
             for col in columns:
-                template = '{0:%d}' % widths[col]
+                template = six.text_type('{0:%d}') % widths[col]
                 value = self.get_print_value(raw_row, col)
                 # Right-align certain native data types
                 if isinstance(raw_row.get(col, 'N/A'), (bool, int)):


### PR DESCRIPTION
The prior fix to the issue was kind of a mess. Also, this fixes the problem with the columns not aligning right:

```
tower-cli inventory list
== =============================== ============ 
id              name               organization 
== =============================== ============ 
 2 Alan AWS                                   1
 4 Custom Script Example                      1
 8 Custom script inventory                    4
 3 ❤ ☀ ☆ ☂ ☻ ♞ ☯ devstack                     1
 1 Farmington_animals                         1
 6 localhost                                  1
 5 other_org_inventory                        2
 7 Production                                 3
 9 tower-cli manual examples                  1
10 tower-cli SCM inventory example            1
== =============================== ============ 
```

What it used to do:

```
tower-cli inventory list
== ==================================== ============ 
id                 name                 organization 
== ==================================== ============ 
 2 Alan AWS                                        1
 4 Custom Script Example                           1
 8 Custom script inventory                         4
 3 ❤ ☀ ☆ ☂ ☻ ♞ ☯ devstack            1
 1 Farmington_animals                              1
 6 localhost                                       1
 5 other_org_inventory                             2
 7 Production                                      3
 9 tower-cli manual examples                       1
10 tower-cli SCM inventory example                 1
== ==================================== ============ 
```

The root of the problem was _not_ that we had a non-unicode type for the name. The problem was the the string that we combined it with wasn't marked with the magic `u` at the beginning.