### PR TITLE
just return list of ids for multiple results, format=id

### DIFF
--- a/tower_cli/cli/resource.py
+++ b/tower_cli/cli/resource.py
@@ -140,10 +140,9 @@ class ResSubcommand(click.MultiCommand):
         """Echos only the id"""
         if 'id' in payload:
             return str(payload['id'])
-        if 'results' in payload and payload['count'] == 1:
-            return str(payload['results'][0]['id'])
-        raise MultipleRelatedError(
-            'Can not use id format when multiple objects are returned.')
+        if 'results' in payload:
+            return ' '.join([six.text_type(item['id']) for item in payload['results']])
+        raise MultipleRelatedError('Could not serialize output with id format.')
 
     @staticmethod
     def get_print_value(data, col):


### PR DESCRIPTION
Connect #414 

In the big picture, it's easier to just return a list of ids than raise errors in this case.

```
tower-cli schedule list --format=id
3 1 2
```

Not actually useful, but keeps the exit codes consistent.