### PR TITLE
remove support for old-style Tower Auth Tokens in 3.3

### DIFF
--- a/docs/source/api_ref/conf.rst
+++ b/docs/source/api_ref/conf.rst
@@ -29,7 +29,7 @@ available Tower CLI settings:
 +------------------+-------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |``certificate``   | String/''                                             | Path to a custom certificate file that will be used throughout the command. Ignored if `--insecure` flag if set in command or `verify_ssl` is set to false |
 +------------------+-------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|``use_token``     | Boolean/'false'                                       | Whether to use token-based authentication.                                                                                                                 |
+|``use_token``     | Boolean/'false'                                       | Whether to use token-based authentication.  No longer supported in Tower 3.3 and above                                                                     |
 +------------------+-------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 **Note:** Some settings are marked as 'CLI use only', this means although users are free to set values to those

--- a/docs/source/cli_ref/index.rst
+++ b/docs/source/cli_ref/index.rst
@@ -166,8 +166,6 @@ and ``tower-cli {resource} {action} --help`` shows details of the usage of this 
                          False]
 
     Global Options:
-      --use-token                     Turn on Tower's token-based authentication.
-                                      Set config use_token to make this permanent.
       --certificate TEXT              Path to a custom certificate file that will
                                       be used throughout the command. Overwritten
                                       by --insecure flag if set.
@@ -192,6 +190,8 @@ and ``tower-cli {resource} {action} --help`` shows details of the usage of this 
                                       "http://" is explicitly provided. This will
                                       take precedence over a host provided to
                                       `tower config`, if any.
+      --use-token                     Turn on Tower's token-based authentication.
+                                      No longer supported in Tower 3.3 and above
 
     Other Options:
       --help  Show this message and exit.

--- a/tower_cli/conf.py
+++ b/tower_cli/conf.py
@@ -446,8 +446,8 @@ def with_global_options(method):
     method = click.option(
         '--use-token',
         default=None,
-        help='Turn on Tower\'s token-based authentication. Set config'
-             ' use_token to make this permanent.',
+        help='Turn on Tower\'s token-based authentication. No longer supported '
+             'in Tower 3.3 and above.',
         is_flag=True,
         required=False, callback=_apply_runtime_setting,
         is_eager=True


### PR DESCRIPTION
related: https://github.com/ansible/tower-cli/issues/478