### PR TITLE
support authentication via oauth2 personal access tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,44 +1,21 @@
-This README documentation walks you through the process of generating a local doc site for Tower CLI.
+This README documentation walks you through the process of generating a local
+doc site for Tower CLI.
 
-Before the actual generating process, make sure you have cloned Tower CLI from github and checked out the right
-version tag you want to generate docs from. Also, we use [graphviz](http://www.graphviz.org/) for some graph
-generations in doc. Make sure to install graphviz. For example, on OS X:
+Before the actual generating process, make sure you have cloned Tower CLI from
+github and checked out the right version tag you want to generate docs from.
+Also, we use [graphviz](http://www.graphviz.org/) for some graph generations in
+doc. Make sure to install graphviz. For example, on OS X:
+
 ```
 $ brew install graphviz
 ```
-It is always suggested you generate docs in a python virtual environment to prevent any dependency conflicts.
-```
-$ virtualenv docs
-```
-And
-```
-source docs/bin/activate
-```
-to activate the virtual environment.
 
-In the newly created empty virtual environment, install [sphinx](http://www.sphinx-doc.org/en/stable/), our doc
-generating engine.
-```
-$ sudo pip install sphinx
-```
-Sphinx walks through an existing python package's source code tree to generate its documentation. so make sure tower
-CLI is installed also.
-```
-$ cd <tower-cli's repo>
-$ make install
-```
-Then, under `docs/` directory, `mkdir build` to create the subdirectory for hosting the local doc site. Also, under
-`docs/source`, `mkdir _static` and `mkdir _templates` which are necessary placeholders for doc site compilation.
+It is always suggested you generate docs in a python virtual environment to
+prevent any dependency conflicts.  To simplify this process, we use `tox`:
 
-In Tower CLI, each resource has a lot of fields that need to be grouped and documented as `.rst`-formatted tables.
-we provide a script, `docs/source/api_ref/generate_tables.py`, to auto-generate all tables. In order to run the
-script, `cd docs/source/api_ref/` and
 ```
-$ python generate_tables.py
+$ tox -edocs
 ```
-Now that all documentation source scripts are ready, navigate to `docs/` directory and generate the doc site by
-```
-$ make html
-```
-Finally, in web browser, navigate to `file://<wherever tower-cli's repo is>/docs/build/html/index.html` and see
-the site for yourself.
+
+Once tox finishes, navigate to `file://<wherever tower-cli's repo
+is>/docs/build/html/index.html` in a web browser to view the HTML documentation.

--- a/docs/source/api_ref/index.rst
+++ b/docs/source/api_ref/index.rst
@@ -1,3 +1,5 @@
+.. _api_ref:
+
 API Reference
 =============
 

--- a/docs/source/cli_ref/index.rst
+++ b/docs/source/cli_ref/index.rst
@@ -1,3 +1,5 @@
+.. _cli_ref:
+
 CLI Reference
 =============
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ============
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -2,27 +2,47 @@ Quick Start
 ===========
 
 This chapter walks you through the general process of setting up and using Tower CLI. It starts with CLI usage
-and ends with API usage. For details, please see API and CLI references in subsequent chapters.
+and ends with API usage. For futher details, please see :ref:`api_ref` and
+:ref:`cli_ref`.
 
-It is assumed you have a Tower backend available to talk to and Tower CLI installed. Please see 'Installation'
-chapter for instructions on installing Tower CLI.
+It is assumed you have a Tower backend available to talk to and Tower CLI installed. Please see the :ref:`installation` chapter for instructions on installing Tower CLI.
 
 First of all, make sure you know the name of the Tower backend, like ``tower.example.com``, as well as the
-username/password set of a user in that Tower backend, like ``user/pass``. These are connection information
+username/password set of a user in that Tower backend, like ``user/pass``. These are connection details
 necessary for Tower CLI to communicate to Tower. With these prerequisites, run
 
 .. code:: bash
 
     $ tower-cli config host tower.example.com
-    $ tower-cli config username user
-    $ tower-cli config password pass
+    $ tower-cli login username
+    Password:
 
-The first Tower CLI command, ``tower-cli config``. writes the connection information to a configuration file
-(``~/.tower-cli.cfg`` in this case), and subsequent commands and API calls will read this file, extract connection
-information and talk to Tower as the specified user. See details of Tower CLI configuration in API reference and
+The first Tower CLI command, ``tower-cli config``, writes the connection information to a configuration file
+(``~/.tower-cli.cfg``, by default), and subsequent commands and API calls will read this file, extract connection
+information and interact with Tower. See details of Tower CLI configuration in :ref:`api_ref` and
 ``tower-cli config --help``.
 
-Then, use Tower CLI to actually control your Tower backend. The CRUD operations against almost every Tower resource
+The second command, ``tower-cli login``, will prompt you for your password and
+will acquire an OAuth2 token (which will also be saved to a configuration
+file) with write scope.  You can also request read scope for read-only access:
+
+.. code:: bash
+
+    $ tower-cli login username --scope read
+    Password:
+
+.. note::
+
+    Older versions of Tower (prior to 3.3) do not support OAuth2 token
+    authentication, and instead utilize per-request basic HTTP authentication:
+
+.. code:: bash
+
+    $ tower-cli config host tower.example.com
+    $ tower-cli config username user
+    $ tower-cli config username pass
+
+Next, use Tower CLI to actually control your Tower backend. The CRUD operations against almost every Tower resource
 can be done using Tower CLI. Suppose we want to see the available job templates to choose for running:
 
 .. code:: bash

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -330,11 +330,12 @@ class LoginTests(unittest.TestCase):
                         'token': 'abc123'
                     }), status_code=201, method='POST')
                     result = self.runner.invoke(
-                        login, ['bob', '--password', 'secret']
+                        login, ['bob', '--password', 'secret', '--scope', 'read']
                     )
 
         # Ensure that we got a zero exit status
         self.assertEqual(result.exit_code, 0)
+        assert json.loads(t.requests[-1].body)['scope'] == 'read'
 
         # Ensure that the output seems to be correct.
         self.assertIn(mock.call(os.path.expanduser('~/.tower_cli.cfg'), 'w'),

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -21,6 +21,7 @@ import warnings
 import click
 from click.testing import CliRunner
 from fauxquests.response import Resp
+from fauxquests.utils import URL
 import requests
 
 import tower_cli
@@ -299,7 +300,9 @@ class LoginTests(unittest.TestCase):
             # register a URL endpoint that _doesn't_ have the version
             # prefix
             prefix = Client().get_prefix(include_version=False)
-            t._registry[prefix + 'o/'] = Resp(''.encode('utf-8'), 404, {})
+            t._registry[URL(prefix + 'o/', method='HEAD')] = Resp(
+                ''.encode('utf-8'), 404, {}
+            )
             result = self.runner.invoke(
                 login, ['bob', '--password', 'secret']
             )
@@ -325,7 +328,9 @@ class LoginTests(unittest.TestCase):
                     # register a URL endpoint that _doesn't_ have the version
                     # prefix
                     prefix = Client().get_prefix(include_version=False)
-                    t._registry[prefix + 'o/'] = Resp(''.encode('utf-8'), 200, {})
+                    t._registry[URL(prefix + 'o/', method='HEAD')] = Resp(
+                        ''.encode('utf-8'), 200, {}
+                    )
                     t.register('/users/bob/personal_tokens/', json.dumps({
                         'token': 'abc123'
                     }), status_code=201, method='POST')
@@ -352,7 +357,9 @@ class LoginTests(unittest.TestCase):
             # register a URL endpoint that _doesn't_ have the version
             # prefix
             prefix = Client().get_prefix(include_version=False)
-            t._registry[prefix + 'o/'] = Resp(''.encode('utf-8'), 200, {})
+            t._registry[URL(prefix + 'o/', method='HEAD')] = Resp(
+                ''.encode('utf-8'), 200, {}
+            )
             t.register('/users/bob/personal_tokens/', json.dumps({}),
                        status_code=401, method='POST')
             result = self.runner.invoke(

--- a/tower_cli/api.py
+++ b/tower_cli/api.py
@@ -189,7 +189,7 @@ class Client(Session):
         response.
         """
         # Piece together the full URL.
-        use_version = not url.endswith('/o/')
+        use_version = not url.startswith('/o/')
         url = '%s%s' % (self.get_prefix(use_version), url.lstrip('/'))
 
         # Ansible Tower expects authenticated requests; add the authentication

--- a/tower_cli/api.py
+++ b/tower_cli/api.py
@@ -236,12 +236,12 @@ class Client(Session):
         # Sanity check: Did we fail to authenticate properly?
         # If so, fail out now; this is always a failure.
         if r.status_code == 401:
-            raise exc.AuthError('Invalid Tower authentication credentials.')
+            raise exc.AuthError('Invalid Tower authentication credentials (HTTP 401).')
 
         # Sanity check: Did we get a forbidden response, which means that
         # the user isn't allowed to do this? Report that.
         if r.status_code == 403:
-            raise exc.Forbidden("You don't have permission to do that.")
+            raise exc.Forbidden("You don't have permission to do that (HTTP 403).")
 
         # Sanity check: Did we get a 404 response?
         # Requests with primary keys will return a 404 if there is no response,

--- a/tower_cli/api.py
+++ b/tower_cli/api.py
@@ -30,7 +30,7 @@ from requests.auth import AuthBase, HTTPBasicAuth
 
 from tower_cli import exceptions as exc
 from tower_cli.conf import settings
-from tower_cli.utils import data_structures, debug, secho
+from tower_cli.utils import data_structures, debug, secho, supports_oauth
 from tower_cli.constants import CUR_API_VERSION
 
 
@@ -47,7 +47,7 @@ class BasicTowerAuth(AuthBase):
 
     def _acquire_token(self):
         return self.cli_client._make_request(
-            'POST', self.cli_client.prefix + 'authtoken/', [],
+            'POST', self.cli_client.get_prefix() + 'authtoken/', [],
             {'data': json.dumps({'username': self.username, 'password': self.password}),
              'headers': {'Content-Type': 'application/json'}}
         ).json()
@@ -78,9 +78,19 @@ class BasicTowerAuth(AuthBase):
             return 'Token ' + token_json['token']
 
     def __call__(self, r):
+        if 'Authorization' in r.headers:
+            return r
+        if settings.oauth_token:
+            if supports_oauth:
+                r.headers['Authorization'] = 'Bearer {}'.format(settings.oauth_token)
+                return r
+            else:
+                warnings.warn(
+                    'This version of Tower does not support OAuth2.0'
+                )
         if self.use_legacy_token:
             resp = self.cli_client._make_request(
-                'OPTIONS', self.cli_client.prefix + 'authtoken/', [], {}
+                'OPTIONS', self.cli_client.get_prefix() + 'authtoken/', [], {}
             )
             if resp.ok:
                 r.headers['Authorization'] = self._get_auth_token()
@@ -156,8 +166,7 @@ class Client(Session):
                 'Right now it is: "%s".' % settings.host
             )
 
-    @property
-    def prefix(self):
+    def get_prefix(self, include_version=True):
         """Return the appropriate URL prefix to prepend to requests,
         based on the host provided in settings.
         """
@@ -169,7 +178,10 @@ class Client(Session):
                 'Can not verify ssl with non-https protocol. Change the '
                 'verify_ssl configuration setting to continue.'
             )
-        return '%s/api/%s/' % (host.rstrip('/'), CUR_API_VERSION)
+        prefix = os.path.sep.join([host.rstrip('/'), 'api', ''])
+        if include_version:
+            prefix = os.path.sep.join([prefix.rstrip('/'), CUR_API_VERSION, ''])
+        return prefix
 
     @functools.wraps(Session.request)
     def request(self, method, url, *args, **kwargs):
@@ -177,7 +189,8 @@ class Client(Session):
         response.
         """
         # Piece together the full URL.
-        url = '%s%s' % (self.prefix, url.lstrip('/'))
+        use_version = not url.endswith('/o/')
+        url = '%s%s' % (self.get_prefix(use_version), url.lstrip('/'))
 
         # Ansible Tower expects authenticated requests; add the authentication
         # from settings if it's provided.
@@ -286,7 +299,7 @@ class Client(Session):
                                      verbose=False, format='json'):
             adapters = copy.copy(self.adapters)
             faux_adapter = FauxAdapter(
-                url_pattern=self.prefix.rstrip('/') + '%s',
+                url_pattern=self.get_prefix().rstrip('/') + '%s',
             )
 
             try:

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -240,6 +240,9 @@ def login(username, password, scope, verbose):
         result = r.json()
         result.pop('summary_fields', None)
         result.pop('related', None)
-        token = result['token']
+        token = result.pop('token', None)
+        if settings.verbose:
+            # only print the actual token if -v
+            result['token'] = token
         secho(json.dumps(result, indent=1), fg='blue', bold=True)
         config.main(['oauth_token', token, '--scope=user'])

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -30,7 +30,7 @@ from tower_cli.conf import with_global_options, Parser, settings, _apply_runtime
 from tower_cli.utils import secho, supports_oauth
 from tower_cli.constants import CUR_API_VERSION
 
-__all__ = ['version', 'config', 'login']
+__all__ = ['version', 'config', 'login', 'logout']
 
 
 @click.command()
@@ -236,7 +236,7 @@ def login(username, password, scope, verbose):
         headers=req.headers
     )
 
-    if r.status_code == 201:
+    if r.ok:
         result = r.json()
         result.pop('summary_fields', None)
         result.pop('related', None)
@@ -246,3 +246,15 @@ def login(username, password, scope, verbose):
             result['token'] = token
         secho(json.dumps(result, indent=1), fg='blue', bold=True)
         config.main(['oauth_token', token, '--scope=user'])
+
+
+@click.command()
+def logout():
+    """
+    Removes an OAuth2 personal auth token from config.
+    """
+    if not supports_oauth():
+        raise exc.TowerCLIError(
+            'This version of Tower does not support OAuth2.0'
+        )
+    config.main(['oauth_token', '--unset', '--scope=user'])

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -212,11 +212,12 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
 @click.command()
 @click.argument('username', required=True)
 @click.option('--password', required=True, prompt=True, hide_input=True)
-@with_global_options
+@click.option('--scope', required=False, default='write',
+              type=click.Choice(['read', 'write']))
 @click.option('-v', '--verbose', default=None,
               help='Show information about requests being made.', is_flag=True,
               required=False, callback=_apply_runtime_setting, is_eager=True)
-def login(username, password):
+def login(username, password, scope, verbose):
     """
     Retrieves and stores an OAuth2 personal auth token.
     """
@@ -231,7 +232,7 @@ def login(username, password):
     HTTPBasicAuth(username, password)(req)
     r = client.post(
         '/users/{}/personal_tokens/'.format(username),
-        data={"description": "Tower CLI", "application": None, "scope": "read"},
+        data={"description": "Tower CLI", "application": None, "scope": scope},
         headers=req.headers
     )
 

--- a/tower_cli/conf.py
+++ b/tower_cli/conf.py
@@ -38,7 +38,7 @@ CONFIG_FILENAME = '.tower_cli.cfg'
 CONFIG_OPTIONS = frozenset((
     'host', 'username', 'password', 'verify_ssl', 'format',
     'color', 'verbose', 'description_on', 'certificate',
-    'use_token'
+    'use_token', 'oauth_token'
 ))
 
 
@@ -344,8 +344,9 @@ def _apply_runtime_setting(ctx, param, value):
 
 
 SETTINGS_PARMS = set([
-    'tower_host', 'tower_password', 'format', 'tower_username', 'verbose',
-    'description_on', 'insecure', 'certificate', 'use_token'
+    'tower_host', 'tower_oauth_token', 'tower_password', 'format',
+    'tower_username', 'verbose', 'description_on', 'insecure', 'certificate',
+    'use_token'
 ])
 
 
@@ -374,6 +375,14 @@ def with_global_options(method):
         help='The location of the Ansible Tower host. '
              'HTTPS is assumed as the protocol unless "http://" is explicitly '
              'provided. This will take precedence over a host provided to '
+             '`tower config`, if any.',
+        required=False, callback=_apply_runtime_setting,
+        is_eager=True
+    )(method)
+    method = click.option(
+        '-t', '--tower-oauth-token',
+        help='OAuth2 token to use to authenticate to Ansible Tower. '
+             'This will take precedence over a token provided to '
              '`tower config`, if any.',
         required=False, callback=_apply_runtime_setting,
         is_eager=True

--- a/tower_cli/utils/__init__.py
+++ b/tower_cli/utils/__init__.py
@@ -40,7 +40,7 @@ def supports_oauth():
     # Import here to avoid a circular import
     from tower_cli.api import client
     try:
-        resp = client.get('/o/')
+        resp = client.head('/o/')
     except exceptions.NotFound:
         return False
     return resp.ok

--- a/tower_cli/utils/__init__.py
+++ b/tower_cli/utils/__init__.py
@@ -34,3 +34,13 @@ def secho(message, **kwargs):
 
     # Okay, now call click.secho normally.
     return click.secho(message, **kwargs)
+
+
+def supports_oauth():
+    # Import here to avoid a circular import
+    from tower_cli.api import client
+    try:
+        resp = client.get('/o/')
+    except exceptions.NotFound:
+        return False
+    return resp.ok

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,12 @@ deps =
 deps = flake8
 commands = flake8 {toxinidir}
 
+[testenv:docs]
+deps = {[testenv]deps}
+        sphinx
+changedir = docs
+commands = python source/api_ref/generate_tables.py
+            make html
+
 [flake8]
 max-line-length=120


### PR DESCRIPTION
see: https://github.com/ansible/tower-cli/issues/478

```
$ tower-cli config host tower.example.org
Configuration updated successfully.

$ tower-cli login bob
Password:
Configuration updated successfully.

$ cat ~/.tower_cli.cfg
[general]
host = tower.example.org
oauth_token = 6LvR6QhttzU2cpIBHc2uOqMbCEbPcH

$ tower-cli inventory list
== ============== ============
id      name      organization
== ============== ============
 1 Demo Inventory            1
== ============== ============
```