### PR TITLE
fixing missing instance_group plurality

### DIFF
--- a/tower_cli/resources/inventory.py
+++ b/tower_cli/resources/inventory.py
@@ -39,7 +39,7 @@ class Resource(models.Resource):
                                help_text='The host_filter field. Only useful when kind=smart.')
     insights_credential = models.Field(display=False, required=False, type=types.Related('credential'))
 
-    instance_group = models.ManyToManyField('instance_group', method_name='ig')
+    instance_groups = models.ManyToManyField('instance_group', method_name='ig')
 
     @resources.command(ignore_defaults=True)
     def batch_update(self, pk=None, **kwargs):


### PR DESCRIPTION
Before:
```
[root@ansible1 tower-cli]# tower-cli inventory associate_ig --inventory "DMZ" --instance_group "tower" -p password -u admin --insecure --tower-host "https://localhost" -v
*** DETAILS: The inventory field is given as a name; looking it up. ***********
*** DETAILS: Getting the record. **********************************************
GET https://localhost/api/v2/inventories/
Params: {'name': 'AT-A-DMZ'}

*** DETAILS: The instance_group field is given as a name; looking it up. ******
*** DETAILS: Getting the record. **********************************************
GET https://localhost/api/v2/instance_groups/
Params: {'name': 'tower'}

GET https://localhost/api/v2/inventories/45/instance_group/
Params: {'id': 1}

Error: The requested object could not be found.
```

After:
```
[root@ansible1 tower-cli]# tower-cli inventory associate_ig --inventory "DMZ" --instance_group "tower" -p password -u admin --insecure --tower-host "https://localhost" -v
*** DETAILS: The inventory field is given as a name; looking it up. ***********
*** DETAILS: Getting the record. **********************************************
GET https://localhost/api/v2/inventories/
Params: {'name': 'AT-A-DMZ'}

*** DETAILS: The instance_group field is given as a name; looking it up. ******
*** DETAILS: Getting the record. **********************************************
GET https://localhost/api/v2/instance_groups/
Params: {'name': 'tower'}

GET https://localhost/api/v2/inventories/45/instance_groups/
Params: {'id': 1}

OK. (changed: false)
```