### PR TITLE
Don't fail when 'prevent' switch match an asset

### DIFF
--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -338,6 +338,8 @@ def receive(organization=None, user=None, team=None, credential_type=None, crede
 @click.option('--prevent', multiple=True, required=False,
               help='Prevents import of a specific asset type.\n'
               'Multiple prevent options can be passed.')
+@click.option('--exclude', multiple=True, required=False, help='Ignore specific asset type. Multiple exclude options '
+              'can be passed.')
 @click.option('--secret_management', multiple=False, required=False, default='default',
               type=click.Choice(['default', 'prompt', 'random']),
               help='What to do with secrets for new items.\n'
@@ -348,7 +350,7 @@ def receive(organization=None, user=None, team=None, credential_type=None, crede
 @click.option('--no-color', is_flag=True,
               help="Disable color output"
               )
-def send(source=None, prevent=None, secret_management='default', no_color=False):
+def send(source=None, prevent=None, exclude=None, secret_management='default', no_color=False):
     """Import assets into Tower.
 
     'tower send' imports one or more assets into a Tower instance
@@ -363,7 +365,7 @@ def send(source=None, prevent=None, secret_management='default', no_color=False)
 
     from tower_cli.cli.transfer.send import Sender
     sender = Sender(no_color)
-    sender.send(source, prevent, secret_management)
+    sender.send(source, prevent, exclude, secret_management)
 
 
 @click.command()

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -339,8 +339,9 @@ def receive(organization=None, user=None, team=None, credential_type=None, crede
               help='Prevents import of a specific asset type.\n'
               'Multiple prevent options can be passed.\n'
               'If an asset type in the prevent list tries to be imported an error will occur')
-@click.option('--exclude', multiple=True, required=False, help='Ignore specific asset type. Multiple exclude options '
-              'can be passed. If an asset type in the exclude list tries to be imprted it will be ignored without an error')
+@click.option('--exclude', multiple=True, required=False, help='Ignore specific asset type.\n'
+              'Multiple exclude options can be passed.\n'
+              'If an asset type in the exclude list tries to be imprted it will be ignored without an error')
 @click.option('--secret_management', multiple=False, required=False, default='default',
               type=click.Choice(['default', 'prompt', 'random']),
               help='What to do with secrets for new items.\n'

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -337,9 +337,10 @@ def receive(organization=None, user=None, team=None, credential_type=None, crede
 @click.argument('source', required=False, nargs=-1)
 @click.option('--prevent', multiple=True, required=False,
               help='Prevents import of a specific asset type.\n'
-              'Multiple prevent options can be passed.')
+              'Multiple prevent options can be passed.\n'
+              'If an asset type in the prevent list tries to be imported an error will occur')
 @click.option('--exclude', multiple=True, required=False, help='Ignore specific asset type. Multiple exclude options '
-              'can be passed.')
+              'can be passed. If an asset type in the exclude list tries to be imprted it will be ignored without an error')
 @click.option('--secret_management', multiple=False, required=False, default='default',
               type=click.Choice(['default', 'prompt', 'random']),
               help='What to do with secrets for new items.\n'

--- a/tower_cli/cli/transfer/send.py
+++ b/tower_cli/cli/transfer/send.py
@@ -22,7 +22,7 @@ class Sender(LoggingCommand):
     def __init__(self, no_color):
         self.no_color = no_color
 
-    def send(self, source, prevent, secret_management):
+    def send(self, source, prevent, exclude, secret_management):
         self.secret_management = secret_management
 
         self.print_intro()
@@ -34,7 +34,7 @@ class Sender(LoggingCommand):
 
         # Next we will sort all of the assets by their type again, will raise if there are errors
         # This is setting sorted_assets
-        self.prep_and_sort_all_assets(import_json, prevent)
+        self.prep_and_sort_all_assets(import_json, prevent, exclude)
 
         for asset_type in common.SEND_ORDER:
             # If we don't have any of this asset type we can move on
@@ -547,7 +547,7 @@ class Sender(LoggingCommand):
 
         return post_check_succeeded
 
-    def prep_and_sort_all_assets(self, import_json, prevent):
+    def prep_and_sort_all_assets(self, import_json, prevent, exclude):
         self.sorted_assets = {}
         had_sort_issues = False
         for asset in import_json:
@@ -562,6 +562,11 @@ class Sender(LoggingCommand):
             if asset_type not in common.SEND_ORDER:
                 self.log_error("Asset type of {} is invalid".format(asset_type))
                 had_sort_issues = True
+                continue
+
+            # Make sure we want to import this asset type
+            if exclude is not None and asset_type in exclude:
+                self.log_ok("Asset of type {} is prevented from importation".format(asset_type))
                 continue
 
             # Make sure we are able to import this asset type

--- a/tower_cli/cli/transfer/send.py
+++ b/tower_cli/cli/transfer/send.py
@@ -564,15 +564,15 @@ class Sender(LoggingCommand):
                 had_sort_issues = True
                 continue
 
-            # Make sure we want to import this asset type
-            if exclude is not None and asset_type in exclude:
-                self.log_ok("Asset of type {} is prevented from importation".format(asset_type))
-                continue
-
             # Make sure we are able to import this asset type
             if prevent is not None and asset_type in prevent:
                 self.log_error("Asset of type {} is prevented from importation".format(asset_type))
                 had_sort_issues = True
+                continue
+
+            # Make sure we want to import this asset type
+            if exclude is not None and asset_type in exclude:
+                self.log_ok("Asset of type {} is prevented from importation".format(asset_type))
                 continue
 
             # Make sure the object has its identifier field


### PR DESCRIPTION
Import with `send` command fails when `prevent` switch match an asset:
```
$ tower-cli send --prevent user config.json -v
Asset of type user is prevented from importation
Error: One or more errors encountered in provided assets, stopping import
```

This pull-request allows to avoid this error (import isn't aborted) without importing excluded assets.