### PR TITLE
Fixed bug where deleting an assigned field was failing.

### DIFF
--- a/tower_cli/cli/transfer/send.py
+++ b/tower_cli/cli/transfer/send.py
@@ -242,10 +242,10 @@ class Sender(LoggingCommand):
                                 reduced_object['credential_type'] = an_asset['credential_type']
 
                         # TowerCLI wants extra_vars to be in a list, not a string
-                        self.touchup_extra_vars(an_asset)
+                        self.touchup_extra_vars(reduced_object)
 
                         try:
-                            resource.write(pk=object_id, **an_asset)
+                            resource.write(pk=object_id, **reduced_object)
                             asset_changed = True
                             self.log_change("Updated asset")
                         except TowerCLIError as e:


### PR DESCRIPTION
For example, if a job template had a description and you tried to remove it the code said that it was removing it but it actually didn't. This was happening because we were not properly passing the reduced object to the write function. The reduced object is a copy of what the user sent to TowerCLI, we then look at each of the properties and compare them to the object already in Tower.
        If the properties are the same we remove them from reduced object.
        If they are different we set them in reduced object.
        If they are only in the reduced object they are new.
        If they are only in the existing object we set them in reduced object to the default value.

When we returned from reducing the object we were incorrectly sending the original object. The net affect was that the first three conditions would always be met but the last condition never applied. So in our case of deleting a job template description the migration reported that it wanted to remove the description but actually did nothing.