### PR TITLE
Fix empty associate method names

### DIFF
--- a/tower_cli/models/fields.py
+++ b/tower_cli/models/fields.py
@@ -160,9 +160,11 @@ class ManyToManyField(BaseField):
             self.res_name = grammar.singularize(attrs.get('endpoint', 'unknown').strip('/'))
 
     def _set_method_names(self, method_name=None, relationship=None):
+        if self.method_name is not None:
+            return  # provided in __init__, do not let metaclass override
+        suffix = ''
         if method_name is not None:
             self.method_name = method_name
-            suffix = ''
             if method_name != '':
                 suffix = '_{}'.format(method_name)
         elif relationship is not None:


### PR DESCRIPTION
Related to https://github.com/ansible/tower-cli/pull/527

The issue is when we declare the field like

```
users = models.ManyToManyField('user', method_name='')
```

This should create commands like

```
tower-cli team associate
```

to associate team members, but this was not working, because the metaclass called the method to set `method_name`, which overwrote the value given in the `__init__`.