### PR TITLE
Fix UnicodeDecodeError (Python 2.7 compatibility)

### DIFF
--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -746,8 +746,7 @@ class MonitorableResource(BaseResource):
         debug.log('Requesting a copy of job standard output', header='details')
         resp = client.get(stdout_url, params=payload).json()
         content = b64decode(resp['content'])
-
-        return content
+        return content.decode('utf-8', 'replace')
 
     @resources.command
     @click.option('--start-line', required=False, type=int, help='Line at which to start printing the standard out.')
@@ -837,7 +836,7 @@ class MonitorableResource(BaseResource):
 
             # In the first moments of running the job, the standard out
             # may not be available yet
-            if not six.text_type(content).startswith("Waiting for results"):
+            if not content.startswith("Waiting for results"):
                 line_count = len(content.splitlines())
                 start_line += line_count
                 click.echo(content, nl=0)


### PR DESCRIPTION
Using Python 2.7 and the following command, raises an `UnicodeDecodeError`:
```tower-cli job launch -J "generate random status" --monitor```

1. `base64.b64decode` returns bytes with Python 2.7 and Python 3+
2.  that explains this commit: https://github.com/ansible/tower-cli/commit/9bbd8aad6b6c1de4ee24bbf2dcbb1be5831ddb72 ([see](https://github.com/ansible/tower-cli/issues/464#issuecomment-369006436)), since `content` is [returned by `base64.b64decode`](https://github.com/ansible/tower-cli/blob/7337795e8500941ededa5ea4f091433baa6ec911/tower_cli/models/base.py#L748) in `lookup_stdout` method.
3. but 9bbd8aad6b6c1de4ee24bbf2dcbb1be5831ddb72 missed the fact that [`lookup_stdout` in workflow_job.py](https://github.com/ansible/tower-cli/blob/7337795e8500941ededa5ea4f091433baa6ec911/tower_cli/resources/workflow_job.py#L50) always returns `unicode` with Python 3.6
4. this was fixed by 7bc22d0c4d8af7411bc51e8cc92c35f3bb3fc276 which added the Python 2.7 incompatibility

Closes #516