### PR TITLE
Now storing password in config files as base64 encoded

### DIFF
--- a/tests/test_utils_password.py
+++ b/tests/test_utils_password.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018, Ansible, Inc.
+# John Westcott <john.westcott.iv@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from tower_cli.utils.password import base64_encode, base64_decode
+
+from tests.compat import unittest
+
+
+class PasswordTests(unittest.TestCase):
+    """A set of tests to establish that the encode/decode methods work
+    """
+
+    def test_encoding_unencoded(self):
+        """Test encoding an unencoded string"""
+        self.assertEqual(base64_encode('test'), 'b64(dGVzdA==)')
+
+    def test_decoding_encoded(self):
+        "Test decoding an encoded string"""
+        self.assertEqual(base64_decode('b64(dGVzdA==)'), 'test')
+
+    def test_encoding_encoded(self):
+        """Test encoding an encoded string"""
+        self.assertEqual(base64_encode('b64(dGVzdA==)'), 'b64(dGVzdA==)')
+
+    def test_decoding_unencoded(self):
+        "Test decoding an unencoded string"""
+        self.assertEqual(base64_decode('test'), 'test')

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -28,6 +28,7 @@ from tower_cli import __version__, exceptions as exc
 from tower_cli.api import client
 from tower_cli.conf import with_global_options, Parser, settings, _apply_runtime_setting
 from tower_cli.utils import secho, supports_oauth
+from tower_cli.utils.password import base64_encode
 from tower_cli.constants import CUR_API_VERSION
 from tower_cli.cli.transfer.common import SEND_ORDER
 
@@ -195,6 +196,8 @@ def config(key=None, value=None, scope='user', global_=False, unset=False):
     if unset:
         parser.remove_option('general', key)
     else:
+        if key == 'password':
+            value = base64_encode(value)
         parser.set('general', key, value)
     with open(filename, 'w') as config_file:
         parser.write(config_file)

--- a/tower_cli/utils/password.py
+++ b/tower_cli/utils/password.py
@@ -1,0 +1,36 @@
+# Copyright 2018, Ansible, Inc.
+# John Westcott <john.westcott.iv@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import re
+
+
+def base64_encode(password):
+    # If the password is already encrypted just return it
+    if re.match("^b64\(.*\)$", password):
+        return password
+
+    encoded_bytes = base64.b64encode(bytearray(password, 'utf-8'))
+    return "b64({})".format(encoded_bytes.decode("utf-8"))
+
+
+def base64_decode(encrypted_string):
+    # If the password is
+    m = re.match("^b64\((.*)\)$", encrypted_string)
+    if not m:
+        return encrypted_string
+
+    unencoded_bytes = base64.b64decode(m.group(1))
+    return unencoded_bytes.decode("utf-8")


### PR DESCRIPTION
This will base64 encode the password fields in the various config files. It will not auto-re-encode existing files but the next time config writes the password to the file it will become encoded.