### PR TITLE
Parse object-type settings as JSON

### DIFF
--- a/tower_cli/resources/setting.py
+++ b/tower_cli/resources/setting.py
@@ -24,6 +24,7 @@ from tower_cli.api import client
 from tower_cli.conf import pop_option
 from tower_cli.cli import types
 from tower_cli.utils.data_structures import OrderedDict
+from tower_cli.utils import debug
 
 
 class Resource(models.Resource):
@@ -155,7 +156,12 @@ class Resource(models.Resource):
         elif to_type == 'boolean':
             return bool(strtobool(value))
         elif to_type in ('list', 'nested object'):
-            return ast.literal_eval(value)
+            try:
+                return json.loads(value)
+            except Exception:
+                debug.log('Could not parse value as JSON, trying as python.',
+                          header='details')
+                return ast.literal_eval(value)
         return value
 
     def __getattribute__(self, name):


### PR DESCRIPTION
Connect https://github.com/ansible/tower-cli/issues/352

It seems that these "nested" settings fields should be JSON. I have no idea where the expectation came from that they would be python format.