### PR TITLE
update login error & docs

### DIFF
--- a/docs/source/CONTRIBUTING.rst
+++ b/docs/source/CONTRIBUTING.rst
@@ -28,8 +28,8 @@ please be patient while we process your request. We will ping you on github once
 Architecture Overview
 ---------------------
 
-All available Tower CLI resources descent from abstract class ``tower_cli.models.base.BaseResource``, which provides
-two fundamental methods, ``read`` and ``write``. ``read`` wraps around a GET method to the specified resource, while
+All available Tower CLI resources descend from the abstract class ``tower_cli.models.base.BaseResource``, which provides
+two fundamental methods, ``read`` and ``write``. The ``read`` method wraps around a GET method to the specified resource, while
 ``write`` wraps around a POST or PATCH on condition. Most public resource APIs, like ``create`` or ``list``, are
 essentially using a combination of ``read`` and ``write`` to communicate with Tower REST APIs.
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -16,7 +16,7 @@
 
 import os
 import sys
-from tests.compat import unittest
+from test.compat import unittest
 
 # Ensure that the tests directory is part of our Python path.
 APP_ROOT = os.path.realpath(os.path.dirname(__file__) + '/../')

--- a/tower_cli/cli/misc.py
+++ b/tower_cli/cli/misc.py
@@ -229,7 +229,7 @@ def login(username, password, scope, client_id, client_secret, verbose):
     """
     if not supports_oauth():
         raise exc.TowerCLIError(
-            'This version of Tower does not support OAuth2.0'
+            'This version of Tower does not support OAuth2.0. Set credentials using tower-cli config.'
         )
 
     # Explicitly set a basic auth header for PAT acquisition (so that we don't


### PR DESCRIPTION
This will hopefully make it clear to set credentials using `tower-cli config` instead of `tower-cli login`.