### PR TITLE
Add multiple statuses processed for the list cmd

### DIFF
--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -279,15 +279,6 @@ class ResourceTests(unittest.TestCase):
             self.res.list(query=[('bar', 'baz')])
             self.assertTrue(t.requests[0].url.endswith('bar=baz'))
 
-    def test_list_duplicate_kwarg(self):
-        """Establish that if we attempt to query on the same field twice,
-        that we get an error.
-        """
-        with client.test_mode as t:
-            with self.assertRaises(exc.BadRequest):
-                self.res.list(name='Batman', query=[('name', 'Robin')])
-            self.assertEqual(len(t.requests), 0)
-
     def test_get_unexpected_zero_results(self):
         """Establish that if a read method gets 0 results when it should have
         gotten one or more, that it raises NotFound.


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR offers to handle multiple statuses while listing Tower objects if available.

Indeed, it is not currently possible to select different statuses and list them in a single CLI call:

```
$ tower-cli job list
== ============ =========================== ========== ============ 
id job_template           created             status     elapsed    
== ============ =========================== ========== ============ 
 5           19 2018-06-30T11:04:24.420148Z failed     14.893
 8           19 2018-06-30T11:52:08.643536Z failed     12.814
13           19 2018-06-30T12:43:32.030374Z failed     9.163
16           19 2018-06-30T12:45:34.288095Z failed     1138.641
20           19 2018-06-30T23:26:41.597881Z canceled   15.289
23           19 2018-06-30T23:32:37.113179Z successful 34.476
26           19 2018-06-30T23:40:28.264561Z successful 232.25
38           20 2018-07-01T00:32:40.124790Z failed     13.7
42           20 2018-07-01T00:35:00.546425Z successful 15.154
46           19 2018-07-01T00:35:33.165234Z successful 129.117
49           21 2018-07-01T00:37:55.220272Z failed     190.465
53           20 2018-07-01T03:05:25.893312Z successful 16.277
56           19 2018-07-01T03:05:55.575079Z failed     142.901
60           20 2018-07-01T04:05:28.665761Z running    28222.825323
64           20 2018-07-01T05:05:32.076526Z canceled   0.0
67           20 2018-07-01T06:05:34.389206Z pending    0.0
69           20 2018-07-01T07:05:36.900398Z canceled   0.0
71           20 2018-07-01T08:05:42.421700Z pending    0.0
73           20 2018-07-01T09:05:42.397185Z pending    0.0
75           20 2018-07-01T10:05:44.946920Z pending    0.0
77           20 2018-07-01T11:05:06.268427Z canceled   0.0
== ============ =========================== ========== ============ 
$
$ tower-cli job list --status running
== ============ =========================== ======= ============ 
id job_template           created           status    elapsed    
== ============ =========================== ======= ============ 
60           20 2018-07-01T04:05:28.665761Z running 28233.051791
== ============ =========================== ======= ============ 
$
$ tower-cli job list --status pending
== ============ =========================== ======= ======= 
id job_template           created           status  elapsed 
== ============ =========================== ======= ======= 
67           20 2018-07-01T06:05:34.389206Z pending 0.0
71           20 2018-07-01T08:05:42.421700Z pending 0.0
73           20 2018-07-01T09:05:42.397185Z pending 0.0
75           20 2018-07-01T10:05:44.946920Z pending 0.0
== ============ =========================== ======= ======= 
$ tower-cli job list --status running,pending
No records found.
```

After implementing this feature, one can successfully list multiple statuses at a time:

```
$ tower-cli job list --status running,pending
== ============ =========================== ========== ============ 
id job_template           created             status     elapsed    
== ============ =========================== ========== ============
60           20 2018-07-01T04:05:28.665761Z running    28222.825323 
67           20 2018-07-01T06:05:34.389206Z pending    0.0
71           20 2018-07-01T08:05:42.421700Z pending    0.0
73           20 2018-07-01T09:05:42.397185Z pending    0.0
75           20 2018-07-01T10:05:44.946920Z pending    0.0
== ============ =========================== ========== ============ 
```