### PR TITLE
#566 Fixed stack trace when exporting a workflow

### DIFF
--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -171,7 +171,16 @@ def extract_workflow_nodes(asset):
         map_node_to_post_options(workflow_node_post_options, workflow_node, node_to_add)
 
         # We can delete the workflow_job_template since we will be applying it to this workflow
-        del node_to_add["workflow_job_template"]
+        if 'workflow_job_template' in node_to_add:
+            del node_to_add["workflow_job_template"]
+
+        # If the unified job template is missing, we can raise an error for this workflow
+        if 'unified_job_template' not in node_to_add:
+            raise TowerCLIError(
+                "Workflow export exception: workflow {} has a node whose job template has been deleted".format(
+                    asset['name']
+                )
+            )
 
         # Now we need to resolve the unified job template
         del node_to_add["unified_job_template"]


### PR DESCRIPTION
If a Workflow had a node whose job template was removed from under it you would get a stack trace. This commit fixes that issue. Now, a message will be displayed:

tower-cli receive --tower-host http://localhost:8081 --workflow "Deleted Node Template" 
Error: Workflow export exception: workflow Deleted Node Template has a node whose job template has been deleted