### PR TITLE
Ensure all output from monitor is directed to outfile

### DIFF
--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -856,7 +856,7 @@ class MonitorableResource(BaseResource):
         job_endpoint = '%s%s/' % (self.unified_job_type, pk)
 
         # Pause until job is in running state
-        self.wait(pk, exit_on=['running', 'successful'])
+        self.wait(pk, exit_on=['running', 'successful'], outfile=outfile)
 
         # Loop initialization
         start = time.time()


### PR DESCRIPTION
If a tower job is not started when the monitor method is called, then wait will generate output `Current status: waiting`. 

Currently this is printed to stdout regardless if an outfile is passed into monitor.

Related to PR #561 