### PR TITLE
Added 'name' field to inventory groups.

### DIFF
--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -313,6 +313,8 @@ def process_inventory_groups(group_json):
     map_node_to_post_options(group_post_options, group_json, group_to_return)
     name_to_id_map = {}
 
+    group_to_return['name'] = group_json['name']
+
     # Now we need to get the children for the group (which should all be groups)
     if 'related' in group_json and 'children' in group_json['related']:
         group_to_return['sub_groups'] = []


### PR DESCRIPTION
Hi,

I described in this bug report that an import of inventories with groups and hosts in it will fail, because the group arrays don't have a 'name' field:

https://github.com/ansible/tower-cli/issues/582

This PR fixes that. Import of inventories with 

```
tower-cli send inventory.json
```

now works.

I would be glad if someone could check that and accept this PR.

Thanks and best regards,

Josef

