### PR TITLE
Additional user information will be exported.

### DIFF
--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -48,6 +48,42 @@ API_POST_OPTIONS = {
             "required": False,
             "default": {}
         }
+    },
+    'user': {
+        "username": {
+            "required": True
+        },
+        "email": {
+            "required": True,
+            "default": ""
+        },
+        "is_superuser": {
+            "required": False,
+            "default": False
+        },
+        "is_system_auditor": {
+            "required": False,
+            "default": False
+        },
+        "first_name": {
+            "required": True,
+            "default": ""
+        },
+        "last_name": {
+            "required": True,
+            "default": ""
+        },
+        "ldap_dn": {
+            "required": False,
+            "default": ""
+        },
+        "auth": {
+            "required": False,
+            "default": []
+        },
+        "external_account": {
+            "required": False
+        }
     }
 }
 NOTIFICATION_TYPES = ['notification_templates_error', 'notification_templates_success']


### PR DESCRIPTION
Hi,

here:
https://github.com/ansible/tower-cli/issues/581

I describe a problem, where the export of 'user' data and the reimport with the same! data doesn't work.

This PR should fix that. For some reason some required fields are not exported with 

```
tower-cli receive --user all > user.json
```

Best regards,

Josef
