### PR TITLE
Fix reported problems associating labels

### DIFF
--- a/docs/source/HISTORY.rst
+++ b/docs/source/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.3.1 (TBD)
+-----------
+
+ - Fixed associating labels to workflows
+ - Associating labels to job template now takes option as --job-template
+
 3.3.0 (2018-04-25)
 ------------------
 

--- a/tower_cli/models/fields.py
+++ b/tower_cli/models/fields.py
@@ -205,12 +205,12 @@ class ManyToManyField(BaseField):
 
         # Apply options for user to specify the 2 resources to associate
         method = click.option(
-            '--{}'.format(self.other_name),
+            '--{}'.format(self.other_name.replace('_', '-')),
             type=types.Related(self.other_name),
             required=True
         )(method)
         method = click.option(
-            '--{}'.format(self.res_name),
+            '--{}'.format(self.res_name.replace('_', '-')),
             type=types.Related(self.res_name),
             required=True
         )(method)

--- a/tower_cli/resources/workflow.py
+++ b/tower_cli/resources/workflow.py
@@ -177,7 +177,7 @@ class Resource(models.SurveyResource):
         help_text='On write commands, perform extra POST to the '
                   'survey_spec endpoint.')
 
-    labels = models.ManyToManyField('label')
+    labels = models.ManyToManyField('label', res_name='workflow')
 
     @staticmethod
     def _workflow_node_structure(node_results):


### PR DESCRIPTION
Addresses https://github.com/ansible/tower-cli/issues/589

```
tower-cli job_template associate_label --job_template=966 --label=foo
OK. (changed: true)
tower-cli workflow associate_label --workflow=362 --label=foo
OK. (changed: false)
```