### PR TITLE
Allow creating schedules with workflow

### DIFF
--- a/tower_cli/resources/schedule.py
+++ b/tower_cli/resources/schedule.py
@@ -23,6 +23,7 @@ UNIFIED_JT = {
     'job_template': '/job_templates',
     'inventory_source': '/inventory_sources',
     'project': '/projects',
+    'workflow': '/workflow_job_templates',
 }
 CLICK_ATTRS = ('__click_params__', '_cli_command', '_cli_command_attrs')
 
@@ -110,6 +111,9 @@ class Resource(models.Resource):
                                     required=False, display=False)
     project = models.Field(type=types.Related('project'), required=False,
                            display=False)
+    workflow = models.Field(
+        type=types.Related('workflow'), required=False, display=False
+    )
 
     # Schedule-specific fields.
     unified_job_template = models.Field(required=False, type=int,


### PR DESCRIPTION
Addresses https://github.com/ansible/tower-cli/issues/570

```
tower-cli schedule create --enabled=false --workflow=346 --rrule="DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1" --name="foo workflow" -v
*** DETAILS: Checking for an existing record. *********************************
GET http://localhost:8013/api/v2/workflow_job_templates/346/schedules/
Params: [('name', u'foo workflow'), ('unified_job_template', 346)]

*** DETAILS: Writing the record. **********************************************
POST http://localhost:8013/api/v2/workflow_job_templates/346/schedules/
Data: {'enabled': False, 'unified_job_template': 346, 'rrule': u'DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1', 'name': u'foo workflow'}

Resource changed.
== ============ ==================== ======= 
id     name     unified_job_template enabled 
== ============ ==================== ======= 
48 foo workflow                  346   false
== ============ ==================== ======= 
```