### PR TITLE
Use related endpoint for schedules if available, always

### DIFF
--- a/tower_cli/resources/schedule.py
+++ b/tower_cli/resources/schedule.py
@@ -70,7 +70,7 @@ def jt_aggregate(func, is_create=False, has_pk=False):
     def decorator_without_pk(obj, *args, **kwargs):
         old_endpoint = obj.endpoint
         new_endpoint = helper(kwargs, obj)
-        if is_create:
+        if new_endpoint:
             obj.endpoint = new_endpoint
         result = func(obj, *args, **kwargs)
         obj.endpoint = old_endpoint
@@ -79,7 +79,7 @@ def jt_aggregate(func, is_create=False, has_pk=False):
     def decorator_with_pk(obj, pk=None, *args, **kwargs):
         old_endpoint = obj.endpoint
         new_endpoint = helper(kwargs, obj)
-        if is_create:
+        if new_endpoint:
             obj.endpoint = new_endpoint
         result = func(obj, pk=pk, *args, **kwargs)
         obj.endpoint = old_endpoint


### PR DESCRIPTION
with change:

```
tower-cli schedule modify --create-on-missing --job-template=1072 --enabled=false --rrule="DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1" --name=foo4 -v
*** DETAILS: Checking for an existing record. *********************************
GET http://localhost:8013/api/v2/job_templates/1072/schedules/
Params: [('name', u'foo4'), ('unified_job_template', 1072)]

*** DETAILS: Writing the record. **********************************************
POST http://localhost:8013/api/v2/job_templates/1072/schedules/
Data: {'enabled': False, 'unified_job_template': 1072, 'rrule': u'DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1', 'name': u'foo4'}

Resource changed.
== ==== ==================== ======= 
id name unified_job_template enabled 
== ==== ==================== ======= 
51 foo4                 1072   false
== ==== ==================== ======= 
```

without change:

```
tower-cli schedule modify --create-on-missing --job-template=1060 --enabled=false --rrule="DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1" --name=foo5 -v
*** DETAILS: Checking for an existing record. *********************************
GET http://localhost:8013/api/v2/schedules/
Params: [('name', u'foo5'), ('unified_job_template', 1060)]

*** DETAILS: Writing the record. **********************************************
POST http://localhost:8013/api/v2/schedules/
Data: {'enabled': False, 'unified_job_template': 1060, 'rrule': u'DTSTART:20180718T155801Z RRULE:FREQ=MONTHLY;INTERVAL=1', 'name': u'foo5'}

Error: The Tower server says you can't make a request with the POST method to that URL (http://localhost:8013/api/v2/schedules/).
```

Addresses https://github.com/ansible/tower-cli/issues/578, while also touching as little as possible here.