### PR TITLE
Avoid ignoring name provided while copying objects

### DIFF
--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -667,8 +667,8 @@ class Resource(BaseResource):
 
         if new_name is None:
             # copy client-side, the old mechanism
-            newresource.update(kwargs)
             newresource['name'] = "%s @ %s" % (basename, time.strftime('%X'))
+            newresource.update(kwargs)
 
             return self.write(create_on_missing=True, **newresource)
         else:


### PR DESCRIPTION
Just switching two lines to first create the default name
with timestamp and then overwrite it with the CLI options.

Closes #471