### PR TITLE
tox: Dropping py26 testenv

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -5,7 +5,7 @@ Env-setup
 ---------
 
 The 'env-setup' script modifies your environment to allow you to run
-tower-cli from a git checkout using python 2.6+.
+tower-cli from a git checkout using python 2.7+.
 
 First, set up your environment to run from the checkout:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,3 @@ colorama>=0.3.1
 requests>=2.3.0
 six>=1.7.2
 PyYAML>=3.10
-
-# === Python < 2.7 ===
-# importlib>=1.0.2
-# ordereddict>=1.1
-# simplejson>=3.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -26,14 +26,6 @@ deps =
     {[testenv]deps}
     mock
 
-[testenv:py26]
-deps =
-    {[testenv:py27]deps}
-    importlib
-    ordereddict
-    simplejson
-    unittest2
-
 [testenv:flake8]
 deps = flake8
 commands = flake8 {toxinidir}


### PR DESCRIPTION
Dropping the tox py26 env as tests are failing with:

```
  prefix = urljoin(prefix, "{}/".format(CUR_API_VERSION))
ValueError: zero length field name in format
```

Current output of running tox:

```
  docs: commands succeeded
  flake8: commands succeeded
  ERROR:   py26: commands failed
  py27: commands succeeded
  py34: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
```

Fixes: https://github.com/ansible/tower-cli/issues/604