### PR TITLE
Add JT custom virtualenv field

### DIFF
--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -60,6 +60,7 @@ class Resource(models.SurveyResource):
                               help_text='Extra variables used by Ansible in YAML or key=value '
                                         'format. Use @ to get YAML from a file.')
     job_tags = models.Field(required=False, display=False)
+    custom_virtualenv = models.Field(required=False, display=False)
     force_handlers = models.Field(type=bool, required=False, display=False)
     skip_tags = models.Field(required=False, display=False)
     start_at_task = models.Field(required=False, display=False)


### PR DESCRIPTION
Resolves https://github.com/ansible/tower-cli/issues/599

Demo:

```
$ tower-cli job_template modify 39 --custom-virtualenv=froobar -v
*** DETAILS: Getting existing record. *****************************************
*** DETAILS: Getting the record. **********************************************
GET http://localhost:8013/api/v2/job_templates/39/
Params: []

*** DETAILS: Writing the record. **********************************************
PATCH http://localhost:8013/api/v2/job_templates/39/
Data: {'custom_virtualenv': u'froobar'}

Error: The Tower server claims it was sent a bad request.

PATCH http://localhost:8013/api/v2/job_templates/39/
Params: None
Data: {"custom_virtualenv": "froobar"}

Response: {"custom_virtualenv":["froobar is not a valid virtualenv in /venv/"]}
```