### PR TITLE
Fixed page numbering when using all-pages and format human

### DIFF
--- a/tests/test_resources_job.py
+++ b/tests/test_resources_job.py
@@ -577,7 +577,7 @@ class ListStatusesTests(unittest.TestCase):
             self.assertEqual(result, {
                 'count': 5,
                 'previous': None,
-                'next': 2,
+                'next': None,
                 'results': [{
                     'elapsed': 0.0,
                     'failed': False,

--- a/tower_cli/cli/resource.py
+++ b/tower_cli/cli/resource.py
@@ -263,7 +263,8 @@ class ResSubcommand(click.MultiCommand):
             '\n'.join(data_rows),
             divider_row,
         ))
-        if page:
+        # Don't print page numbers for 1 page results
+        if page and total_pages != 1:
             response += '(Page %d of %d.)' % (page, total_pages)
         if payload.get('changed', False):
             response = 'Resource changed.\n' + response

--- a/tower_cli/models/base.py
+++ b/tower_cli/models/base.py
@@ -558,6 +558,7 @@ class BaseResource(six.with_metaclass(ResourceMeta)):
                 cursor = self.list(**dict(kwargs, page=cursor['next']))
                 response['results'] += cursor['results']
                 response['count'] += cursor['count']
+            response['next'] = None
 
         # Done; return the response
         return response


### PR DESCRIPTION
This addresses: https://github.com/ansible/tower-cli/issues/650 

Older versions of the CLI did not print page information when there was only 1 page, that seems sensible to me so that's what I went with.   Test case was also updated to assert what I believe is the correct response.