### PR TITLE
Fix deep nested recursion when sending workflows

### DIFF
--- a/tower_cli/resources/node.py
+++ b/tower_cli/resources/node.py
@@ -74,9 +74,17 @@ class Resource(models.Resource):
     )
 
     def __new__(cls, *args, **kwargs):
-        for attr in ['create', 'modify', 'list']:
-            setattr(cls, attr,
-                    unified_job_template_options(getattr(cls, attr)))
+        for attr_name in ['create', 'modify', 'list']:
+
+            attr = getattr(cls, attr_name)
+            if getattr(attr, '__decorator__', None) == 'unified_job_template_options':
+                continue
+
+            wrapped_func = unified_job_template_options(attr)
+            wrapped_func.__decorator__ = 'unified_job_template_options'
+
+            setattr(cls, attr_name, wrapped_func)
+
         return super(Resource, cls).__new__(cls, *args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
This PR fixes issue with big tower-cli asset files with lots of workflows and nodes.
At some point nodes can't be uploaded due to exceeded recursion depth.
The bug itself is due to dynamic decorator creation on every constructor call.

Error log : [node-recursion-log.txt](https://github.com/ansible/tower-cli/files/2951076/node-recursion-log.txt)

