### PR TITLE
grant role to user: handle admin roles with space

### DIFF
--- a/tests/test_resources_role.py
+++ b/tests/test_resources_role.py
@@ -91,6 +91,15 @@ class RoleUnitTests(unittest.TestCase):
         self.assertIn('members__in', data)
         self.assertEqual(endpoint, '/roles/')
 
+    def test_data_endpoint_inventory_admin(self):
+        """Translation of input args to lookup args, space in type"""
+        kwargs = {'user': 2, 'type': 'Inventory Admin', 'inventory': 5}
+        data, endpoint = Role.data_endpoint(kwargs, ignore=['res'])
+        self.assertIn('members__in', data)
+        self.assertEqual(endpoint, '/roles/')
+        self.assertIn('role_field', data)
+        self.assertEqual(data['role_field'], 'inventory_admin_role')
+
 
 class RoleMethodTests(unittest.TestCase):
     """Test role commands."""

--- a/tower_cli/resources/role.py
+++ b/tower_cli/resources/role.py
@@ -172,7 +172,7 @@ class Resource(models.Resource):
         else:
             endpoint = '/roles/'
         if in_data.get('type', False):
-            data['role_field'] = '%s_role' % in_data['type'].lower()
+            data['role_field'] = '%s_role' % in_data['type'].replace(' ', '_').lower()
         # Add back fields unrelated to role lookup, such as all_pages
         for key, value in in_data.items():
             if key not in RESOURCE_FIELDS and key not in ['type', 'user', 'team']:


### PR DESCRIPTION
Fix `Unable to add user` when granted role contains a space:

    $ awx-cli send <<EOF
    [
      {
        "asset_type": "organization",
        "name": "MyOrg",
        "asset_relation": {
          "roles": [
            {
              "name": "Inventory Admin",
              "user": ["misc"],
              "team": []
            }
          ]
        }
      }
    ]
    EOF

    ORGANIZATION [MyOrg] ***
    Asset up to date
    Unable to add user misc to Inventory Admin role: The requested object could not be found.