### PR TITLE
Fix to tower-cli to send and receive ALL credentials

### DIFF
--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -419,18 +419,18 @@ def get_assets_from_input(all=False, asset_input=None):
     return return_assets
 
 
-def extract_extra_credentials(asset):
+def extract_credentials(asset):
     return_credentials = []
     name_to_id_map = {}
 
-    extra_credentials = load_all_assets(asset['related']['extra_credentials'])
-    for a_credential in extra_credentials['results']:
+    credentials = load_all_assets(asset['related']['credentials'])
+    for a_credential in credentials['results']:
         name_to_id_map[a_credential['name']] = a_credential['id']
         return_credentials.append(a_credential['name'])
 
     return {'items': return_credentials, 'existing_name_to_id_map': name_to_id_map}
 
-
+    
 def extract_labels(asset):
     return_labels = []
     name_to_object_map = {}

--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -430,7 +430,6 @@ def extract_credentials(asset):
 
     return {'items': return_credentials, 'existing_name_to_id_map': name_to_id_map}
 
-    
 def extract_labels(asset):
     return_labels = []
     name_to_object_map = {}

--- a/tower_cli/cli/transfer/common.py
+++ b/tower_cli/cli/transfer/common.py
@@ -430,6 +430,7 @@ def extract_credentials(asset):
 
     return {'items': return_credentials, 'existing_name_to_id_map': name_to_id_map}
 
+
 def extract_labels(asset):
     return_labels = []
     name_to_object_map = {}

--- a/tower_cli/cli/transfer/receive.py
+++ b/tower_cli/cli/transfer/receive.py
@@ -97,9 +97,9 @@ class Receiver:
                             exported_asset[common.ASSET_RELATION_KEY][notification_type] = \
                                 common.extract_notifications(asset, notification_type)
 
-                    elif relation == 'extra_credentials':
+                    elif relation == 'credentials':
                         exported_asset[common.ASSET_RELATION_KEY][relation] =\
-                            common.extract_extra_credentials(asset)['items']
+                            common.extract_credentials(asset)['items']
 
                     elif relation == 'schedules':
                         exported_asset[common.ASSET_RELATION_KEY][relation] =\

--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -142,7 +142,7 @@ class Resource(models.SurveyResource):
 
         =====API DOCS=====
         """
-        return self._assoc('extra_credentials', job_template, credential)
+        return self._assoc('credentials', job_template, credential)
 
     @resources.command(use_fields_as_options=False)
     @click.option('--job-template', type=types.Related('job_template'))

--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -28,7 +28,7 @@ class Resource(models.SurveyResource):
     cli_help = 'Manage job templates.'
     endpoint = '/job_templates/'
     dependencies = ['inventory', 'credential', 'project', 'vault_credential']
-    related = ['survey_spec', 'notification_templates', 'extra_credentials', 'schedules', 'labels']
+    related = ['survey_spec', 'notification_templates', 'credentials', 'extra_credentials', 'schedules', 'labels']
 
     name = models.Field(unique=True)
     description = models.Field(required=False, display=False)


### PR DESCRIPTION
As the `/credential` api has been deprecated (https://github.com/ansible/awx/pull/3413) the `tower-cli "send | receive"` is not processing any machine credentials https://github.com/ansible/tower-cli/issues/716.

This PR deprecates the `extra_credentials` from the `send `and `receive `commands and utilizes the `/credentials` api to send and receive all credentials.

```
bash-4.2# tower-cli receive --job_template test
[
  {
    "name": "test",
    "allow_simultaneous": true,
    "asset_relation": {
      "notification_templates_error": [
        "Webhook"
      ],
      "notification_templates_success": [],
      "roles": [
        {
          "team": [],
          "name": "Admin",
          "user": [
            "admin"
          ]
        },
        {
          "team": [],
          "name": "Execute",
          "user": []
        },
        {
          "team": [],
          "name": "Read",
          "user": []
        }
      ],
      "labels": [],
      "schedules": [],
      "credentials": [
        "Machine - Linux",
        "Storage Account Keys"
      ],
      "survey_spec": {}
    },
    "project": "test_project",
    "inventory": "test_inventory",
    "asset_type": "job_template",
    "playbook": "playbook.yml"
  }
]
```