### PR TITLE
Introduce field status to error if server is post-removal

### DIFF
--- a/tests/test_resources_job_template.py
+++ b/tests/test_resources_job_template.py
@@ -41,7 +41,7 @@ class TemplateTests(unittest.TestCase):
             t.register_json(endpoint, {'changed': True, 'id': 42},
                             method='POST')
             self.res.create(name='bar', job_type='run', inventory=1,
-                            project=1, playbook='foobar.yml', credential=1)
+                            project=1, playbook='foobar.yml')
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertEqual(t.requests[1].method, 'POST')
             self.assertEqual(len(t.requests), 2)
@@ -55,7 +55,7 @@ class TemplateTests(unittest.TestCase):
             t.register_json(endpoint, {'changed': True, 'id': 42},
                             method='POST')
             self.res.create(name='bar', inventory=1, project=1,
-                            playbook='foobar.yml', credential=1)
+                            playbook='foobar.yml')
             req_body = json.loads(t.requests[1].body)
             self.assertIn('job_type', req_body)
             self.assertEqual(req_body['job_type'], 'run')
@@ -74,13 +74,13 @@ class TemplateTests(unittest.TestCase):
                                 'playbook': 'foobar.yml', 'credential': 1},
                             method='POST')
             self.res.create(name='bar', job_type='run', inventory=1,
-                            project=1, playbook='foobar.yml', credential=1)
+                            project=1, playbook='foobar.yml')
 
             f = ResSubcommand(self.res)._echo_method(self.res.create)
             with mock.patch.object(click, 'secho'):
                 with settings.runtime_values(format='human'):
                     f(name='bar', job_type='run', inventory=1,
-                      project=1, playbook='foobar.yml', credential=1)
+                      project=1, playbook='foobar.yml')
 
     def test_create_w_extra_vars(self):
         """Establish that a job template can be created
@@ -94,7 +94,7 @@ class TemplateTests(unittest.TestCase):
             t.register_json(endpoint, {'changed': True, 'id': 42},
                             method='POST')
             self.res.create(name='bar', job_type='run', inventory=1,
-                            project=1, playbook='foobar.yml', credential=1,
+                            project=1, playbook='foobar.yml',
                             extra_vars=['foo: bar'])
             self.assertEqual(t.requests[0].method, 'GET')
             self.assertEqual(t.requests[1].method, 'POST')

--- a/tower_cli/cli/resource.py
+++ b/tower_cli/cli/resource.py
@@ -353,6 +353,8 @@ class ResSubcommand(click.MultiCommand):
                     option_help += ' Use @ to get JSON or YAML from a file.'
                 if field.required:
                     option_help = '[REQUIRED] ' + option_help
+                if field.deprecated:
+                    option_help = '[DEPRECATED] ' + option_help
                 elif field.read_only:
                     option_help = '[READ ONLY] ' + option_help
                 option_help = '[FIELD]' + option_help

--- a/tower_cli/models/fields.py
+++ b/tower_cli/models/fields.py
@@ -45,7 +45,8 @@ class Field(BaseField):
                  display=True, filterable=True, help_text=None,
                  is_option=True, password=False, read_only=False,
                  required=True, show_default=False, unique=False,
-                 multiple=False, no_lookup=False, col_width=None):
+                 multiple=False, no_lookup=False, col_width=None,
+                 deprecated=False):
         # Init the name to blank.
         # What's going on here: This is set by the ResourceMeta metaclass
         # when the **resource** is instantiated.
@@ -69,6 +70,7 @@ class Field(BaseField):
         self.multiple = multiple
         self.no_lookup = no_lookup
         self.col_width = col_width
+        self.deprecated = deprecated
 
         # If this is a password, display is always off.
         if self.password:

--- a/tower_cli/resources/job_template.py
+++ b/tower_cli/resources/job_template.py
@@ -40,8 +40,8 @@ class Resource(models.SurveyResource):
     inventory = models.Field(type=types.Related('inventory'), required=False)
     project = models.Field(type=types.Related('project'))
     playbook = models.Field()
-    credential = models.Field(display=False, required=False, type=types.Related('credential'))
-    vault_credential = models.Field(type=types.Related('credential'), required=False, display=False)
+    credential = models.Field(display=False, required=False, type=types.Related('credential'), deprecated=True)
+    vault_credential = models.Field(type=types.Related('credential'), required=False, display=False, deprecated=True)
     forks = models.Field(type=int, required=False, display=False)
     limit = models.Field(required=False, display=False)
     verbosity = models.Field(


### PR DESCRIPTION
A proposed solution to make https://github.com/ansible/tower-cli/issues/719 just a little less bad

```
tower-cli job_template create --name="Hello World Debug" --description="debug statement" --inventory=localhost --credential=user2 --project="Ansible Examples" --playbook=debug.yml -v
*** DETAILS: The inventory field is given as a name; looking it up. ***********
*** DETAILS: Getting the record. **********************************************
GET https://localhost:8043/api/v2/inventories/
Params: [('name', 'localhost')]

*** DETAILS: The credential field is given as a name; looking it up. **********
*** DETAILS: Getting the record. **********************************************
GET https://localhost:8043/api/v2/credentials/
Params: [('name', 'user2')]

*** DETAILS: The project field is given as a name; looking it up. *************
*** DETAILS: Getting the record. **********************************************
GET https://localhost:8043/api/v2/projects/
Params: [('name', 'Ansible Examples')]

*** DETAILS: Checking for an existing record. *********************************
GET https://localhost:8043/api/v2/job_templates/
Params: [('name', u'Hello World Debug')]

*** DETAILS: Writing the record. **********************************************
POST https://localhost:8043/api/v2/job_templates/
Data: {'job_type': u'run', 'playbook': u'debug.yml', 'description': u'debug statement', 'inventory': 2, 'credential': 2, 'name': u'Hello World Debug', 'project': 8}

Due to field error, attempting to delete created item.
DELETE /job_templates/15/
DELETE https://localhost:8043/api/v2/job_templates/15/

Error: The provided fields credential vault_credential were removed in an AWX or Tower release and failed to take effect here.
```

```
tower-cli job_template modify 17 --credential=1
Error: The provided fields credential vault_credential were removed in an AWX or Tower release and failed to take effect here.
```

```
tower-cli job_template create
Usage: tower-cli job_template create [OPTIONS]

  Create a job template.

  Fields in the resource's --identity tuple are used for a lookup; if a
  match is found, then no-op (unless --force-on-exists is set) but do not
  fail (unless --fail-on-found is set).

Field Options:
  -n, --name TEXT                 [REQUIRED] The name field.
  -d, --description TEXT          The description field.
  --job-type [run|check]          The job_type field.
  -i, --inventory INVENTORY       The inventory field.
  --project PROJECT               [REQUIRED] The project field.
  --playbook TEXT                 [REQUIRED] The playbook field.
  --credential CREDENTIAL         [DEPRECATED] The credential field.
  --vault-credential CREDENTIAL   [DEPRECATED] The vault_credential field.
  --forks INTEGER                 The forks field.
  --limit TEXT                    The limit field.
  --verbosity [default|verbose|more_verbose|debug|connection|winrm]
                                  The verbosity field.
  -e, --extra-vars VARIABLES      Extra variables used by Ansible in YAML or
                                  key=value format. Use @ to get YAML from a
                                  file.
  --job-tags TEXT                 The job_tags field.
  --custom-virtualenv TEXT        The custom_virtualenv field.
  --force-handlers BOOLEAN        The force_handlers field.
  --skip-tags TEXT                The skip_tags field.
  --start-at-task TEXT            The start_at_task field.
  --timeout INTEGER               The amount of time (in seconds) to run
                                  before the task is canceled.
  --use-fact-cache BOOLEAN        If enabled, Tower will act as an Ansible
                                  Fact Cache Plugin; persisting facts at the
                                  end of a playbook run to the database and
                                  caching facts for use by Ansible.
  --host-config-key TEXT          Allow Provisioning Callbacks using this host
                                  config key
  --ask-diff-mode-on-launch BOOLEAN
                                  Ask diff mode on launch.
  --ask-variables-on-launch BOOLEAN
                                  Prompt user for extra_vars on launch.
  --ask-limit-on-launch BOOLEAN   Prompt user for host limits on launch.
  --ask-tags-on-launch BOOLEAN    Prompt user for job tags on launch.
  --ask-skip-tags-on-launch BOOLEAN
                                  Prompt user for tags to skip on launch.
  --ask-job-type-on-launch BOOLEAN
                                  Prompt user for job type on launch.
  --ask-verbosity-on-launch BOOLEAN
                                  Prompt user for verbosity on launch.
  --ask-inventory-on-launch BOOLEAN
                                  Prompt user for inventory on launch.
  --ask-credential-on-launch BOOLEAN
                                  Prompt user for machine credential on
                                  launch.
  --survey-enabled BOOLEAN        Prompt user for job type on launch.
  --become-enabled BOOLEAN        The become_enabled field.
  --diff-mode BOOLEAN             If enabled, textual changes made to any
                                  templated files on the host are shown in the
                                  standard output.
  --allow-simultaneous BOOLEAN    The allow_simultaneous field.
  --survey-spec VARIABLES         On write commands, perform extra POST to the
                                  survey_spec endpoint.

Local Options:
  --fail-on-found    If used, return an error if a matching record already
                     exists.  [default: False]
  --force-on-exists  If used, if a match is found on unique fields, other
                     fields will be updated to the provided values. If False,
                     a match causes the request to be a no-op.  [default:
                     False]

Global Options:
  --use-token                     Turn on Tower's token-based authentication.
                                  No longer supported in Tower 3.3 and above.
  --certificate TEXT              Path to a custom certificate file that will
                                  be used throughout the command. Overwritten
                                  by --insecure flag if set.
  --insecure                      Turn off insecure connection warnings. Set
                                  config verify_ssl to make this permanent.
  --description-on                Show description in human-formatted output.
  -v, --verbose                   Show information about requests being made.
  -f, --format [human|json|yaml|id]
                                  Output format. The "human" format is
                                  intended for humans reading output on the
                                  CLI; the "json" and "yaml" formats provide
                                  more data, and "id" echos the object id
                                  only.
  -p, --tower-password TEXT       Password to use to authenticate to Ansible
                                  Tower. This will take precedence over a
                                  password provided to `tower config`, if any.
                                  If value is ASK you will be prompted for the
                                  password
  -u, --tower-username TEXT       Username to use to authenticate to Ansible
                                  Tower. This will take precedence over a
                                  username provided to `tower config`, if any.
  -t, --tower-oauth-token TEXT    OAuth2 token to use to authenticate to
                                  Ansible Tower. This will take precedence
                                  over a token provided to `tower config`, if
                                  any.
  -h, --tower-host TEXT           The location of the Ansible Tower host.
                                  HTTPS is assumed as the protocol unless
                                  "http://" is explicitly provided. This will
                                  take precedence over a host provided to
                                  `tower config`, if any.

Other Options:
  --help  Show this message and exit.
```