### PR TITLE
Fix 'Found more than one unified job' bug

### DIFF
--- a/tower_cli/cli/transfer/send.py
+++ b/tower_cli/cli/transfer/send.py
@@ -899,7 +899,7 @@ class Sender(LoggingCommand):
             unified_job_results = client.request(
                 'get',
                 "unified_job_templates",
-                {'name': job_name, 'type__contains': job_type}
+                {'name': job_name, 'type__startswith': job_type}
             )
 
             # If it failed, move on


### PR DESCRIPTION
Hi :)

the send command can't find the right job, if you setup a job and a workflow with the same name.

Steps to reproduce:
- Create job a
- Create workflow a
- Create workflow b
  - Include Job a

`tower-cli receive --workflow b > b.json`
`tower-cli send b.json`

Cheers
Marcel