### PR TITLE
Fixing parser for tower-cli workflows

### DIFF
--- a/tower_cli/utils/parser.py
+++ b/tower_cli/utils/parser.py
@@ -127,7 +127,7 @@ def process_extra_vars(extra_vars_list, force_json=True):
             opt_dict = string_to_dict(extra_vars_opt, allow_kv=False)
         else:
             # Convert text markup to a dictionary liberally
-            opt_dict = string_to_dict(extra_vars_opt, allow_kv=True)
+            opt_dict = string_to_dict(extra_vars_list, allow_kv=True)
         # Rolling YAML-based string combination
         if any(line.startswith("#") for line in extra_vars_opt.split('\n')):
             extra_vars_yaml += extra_vars_opt + "\n"


### PR DESCRIPTION
I have been trying to use `tower_workflow_template` module and while doing that I ran into failure to parse extra variables. That was because `extra_vars_opt` was looping over `extra_vars` as a string. 
E.g.
```
extra_vars_list="[{ 'var1:'val1' }]"
for extra_var_opts in extra_vars_list:
...   print(extra_var_opts)
... 
[
{
 
'
v
a
r
1
:
'
v
a
l
1
'
 
}
]
```

This would cause my playbook to fail with `unable to parse extra_vars` . @AlanCoding I saw some of your commits in that file from you, please review and help me merge the fix. 
PS I am first time contributor. This solution proposed may not be right for general use, but it seems to fix the problem I had.

Sample workflow that I used:
```
tower_workflows:
  - name: Test workflow
    description: created by Ansible Playbook
    organization: Default
    survey_enabled: false
    allow_simultaneous: no
    schema:
      - job_template: Demo Job Template
    extra_vars:
      var1: val1
      var2:
        var21: val21
        var22: val22
      var3:
        - var4
        - var5
      var6:
        - var7: val7
        - var8: val8
          var9: val9
```