### PR TITLE
Improve error handling for users using the schema command

### DIFF
--- a/docs/source/HISTORY.rst
+++ b/docs/source/HISTORY.rst
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+3.3.9 (2020-03-12)
+------------------
+
+- Improve error handling for template specification in workflow schema command.
+- Pin the click library to avoid changing look and feel of output.
+
 3.3.8 (2020-01-14)
 ------------------
 

--- a/docs/source/cli_ref/usage/WORKFLOWS.rst
+++ b/docs/source/cli_ref/usage/WORKFLOWS.rst
@@ -127,6 +127,16 @@ network with a tower-cli command after the constituent resources like
 the job templates and projects were created by preceding tower-cli
 commands.
 
+Workflows Inside Workflows
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to have a workflow embedded inside of the schema of another
+workflow. To do this, use the key "workflow".
+
+.. code:: yaml
+
+    - workflow: Another workflow
+
 Differences with Machine Formatted Schemas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tower_cli/resources/workflow.py
+++ b/tower_cli/resources/workflow.py
@@ -45,16 +45,19 @@ class TreeNode(object):
             else:
                 node_attrs[fd] = data[fd]
         node_attrs['workflow_job_template'] = wfjt
+        ujt_ambiguity_msg = (
+            'You should provide exactly one of the attributes'
+            ' job_template, project, workflow, inventory_source, or unified_job_template.'
+        )
         for ujt_name in ujt_attrs:
             if ujt_name not in node_attrs:
                 continue
             if 'unified_job_template' not in node_attrs:
                 node_attrs['unified_job_template'] = node_attrs.pop(ujt_name)
             else:
-                raise BadRequest(
-                    'You should not provide more than one of the attributes'
-                    ' job_template, project and inventory_source.'
-                )
+                raise BadRequest(ujt_ambiguity_msg)
+        if 'unified_job_template' not in node_attrs:
+            raise BadRequest(ujt_ambiguity_msg)
         self.unified_job_template = node_attrs.get('unified_job_template', None)
         self.node_attrs = node_attrs
         for rel in ['success_nodes', 'failure_nodes', 'always_nodes']:


### PR DESCRIPTION
It looks like the server stopped verifying that `unified_job_template` has a non-null value because of the additional of approval nodes.

This has a consequence for function of the schema command, since it was never documented how to use workflows-in-workflows. It would silently finish with null nodes, which is a sideways state.