### PR TITLE
Fix bug in notification import

### DIFF
--- a/tower_cli/cli/transfer/send.py
+++ b/tower_cli/cli/transfer/send.py
@@ -1500,7 +1500,7 @@ class Sender(LoggingCommand):
             # If the notification is already in the existing_notifications we don't need to do anything
             # Just remove it from the existing notifications so we dont delete it
             if notification_name in existing_notifications:
-                del existing_notifications[notification_name]
+                existing_notifications.remove(notification_name)
                 continue
 
             try:


### PR DESCRIPTION
When removing a string from a list of strings, `del list["string"]` will cause a "TypeError: list indices must be integers or slices, not str". list.remove("string") must be used.

We can see this when importing notifications:

```log
File "/usr/local/lib/python3.7/site-packages/tower_cli/cli/transfer/send.py", line 1503, in import_notification_relations
  del existing_notifications[notification_name]
TypeError: list indices must be integers or slices, not str
```
